### PR TITLE
Fixed a bug where a bad connection gets reused

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -183,6 +183,8 @@ func (cn *conn) extendDeadline() {
 func (cn *conn) condRelease(err *error) {
 	if *err == nil || resumableError(*err) {
 		cn.release()
+	} else {
+		cn.nc.Close()
 	}
 }
 


### PR DESCRIPTION
While using gomemcache under heavy load I saw a situation where odd errors would occur. Tracked it down to a bad := which should have been =. The result was that an error could get ignored and a bad connection could get reused.
