### PR TITLE
Make the maxIdleConnsPerAddr configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,8 @@ You can use `go get -u -a` for update all installed packages.
             "github.com/bradfitz/gomemcache/memcache"
     )
 
-    const maxIdleConnsPerAddr 2
-
     func main() {
-         mc := memcache.New(maxIdleConnsPerAddr, "10.0.0.1:11211", "10.0.0.2:11211", "10.0.0.3:11212")
+         mc := memcache.New("10.0.0.1:11211", "10.0.0.2:11211", "10.0.0.3:11212")
          mc.Set(&memcache.Item{Key: "foo", Value: []byte("my value")})
 
          it, err := mc.Get("foo")

--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ You can use `go get -u -a` for update all installed packages.
             "github.com/bradfitz/gomemcache/memcache"
     )
 
+    const maxIdleConnsPerAddr 2
+
     func main() {
-         mc := memcache.New("10.0.0.1:11211", "10.0.0.2:11211", "10.0.0.3:11212")
+         mc := memcache.New(maxIdleConnsPerAddr, "10.0.0.1:11211", "10.0.0.2:11211", "10.0.0.3:11212")
          mc.Set(&memcache.Item{Key: "foo", Value: []byte("my value")})
 
          it, err := mc.Get("foo")

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -69,7 +69,6 @@ const DefaultTimeout = time.Duration(100) * time.Millisecond
 
 const (
 	buffered            = 8 // arbitrary buffered channel size, for readability
-	maxIdleConnsPerAddr = 2 // TODO(bradfitz): make this configurable?
 )
 
 // resumableError returns true if err is only a protocol-level cache error.

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -68,7 +68,7 @@ var (
 const DefaultTimeout = time.Duration(100) * time.Millisecond
 
 const (
-	buffered            = 8 // arbitrary buffered channel size, for readability
+	buffered                   = 8 // arbitrary buffered channel size, for readability
 	defaultMaxIdleConnsPerAddr = 2
 )
 

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -69,7 +69,7 @@ const DefaultTimeout = time.Duration(100) * time.Millisecond
 
 const (
 	buffered            = 8 // arbitrary buffered channel size, for readability
-	maxIdleConnsPerAddr = 2
+	defaultMaxIdleConnsPerAddr = 2
 )
 
 // resumableError returns true if err is only a protocol-level cache error.
@@ -127,7 +127,7 @@ func NewWithConnThreshold(threshold int, server ...string) *Client {
 
 // NewFromSelector returns a new Client using the provided ServerSelector.
 func NewFromSelector(ss ServerSelector) *Client {
-	return &Client{selector: ss, maxIdleConnsPerAddr: maxIdleConnsPerAddr}
+	return &Client{selector: ss, maxIdleConnsPerAddr: defaultMaxIdleConnsPerAddr}
 }
 
 // Client is a memcache client.

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -68,7 +68,7 @@ var (
 const DefaultTimeout = time.Duration(100) * time.Millisecond
 
 const (
-	buffered            = 8 // arbitrary buffered channel size, for readability
+	buffered = 8 // arbitrary buffered channel size, for readability
 )
 
 // resumableError returns true if err is only a protocol-level cache error.

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -27,7 +27,10 @@ import (
 	"time"
 )
 
-const testServer = "localhost:11211"
+const (
+    testServer = "localhost:11211"
+    maxIdleConnsPerAddr = 2
+)
 
 func setup(t *testing.T) bool {
 	c, err := net.Dial("tcp", testServer)
@@ -44,7 +47,7 @@ func TestLocalhost(t *testing.T) {
 	if !setup(t) {
 		return
 	}
-	testWithClient(t, New(testServer))
+	testWithClient(t, New(maxIdleConnsPerAddr, testServer))
 }
 
 // Run the memcached binary as a child process and connect to its unix socket.
@@ -66,7 +69,7 @@ func TestUnixSocket(t *testing.T) {
 		time.Sleep(time.Duration(25 * i) * time.Millisecond)
 	}
 
-	testWithClient(t, New(sock))
+	testWithClient(t, New(maxIdleConnsPerAddr, sock))
 }
 
 func testWithClient(t *testing.T, c *Client) {

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -28,8 +28,8 @@ import (
 )
 
 const (
-    testServer = "localhost:11211"
-    maxIdleConnsPerAddr = 2
+	testServer          = "localhost:11211"
+	maxIdleConnsPerAddr = 2
 )
 
 func setup(t *testing.T) bool {
@@ -66,7 +66,7 @@ func TestUnixSocket(t *testing.T) {
 		if _, err := os.Stat(sock); err == nil {
 			break
 		}
-		time.Sleep(time.Duration(25 * i) * time.Millisecond)
+		time.Sleep(time.Duration(25*i) * time.Millisecond)
 	}
 
 	testWithClient(t, New(maxIdleConnsPerAddr, sock))

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -27,10 +27,7 @@ import (
 	"time"
 )
 
-const (
-	testServer          = "localhost:11211"
-	maxIdleConnsPerAddr = 2
-)
+const testServer = "localhost:11211"
 
 func setup(t *testing.T) bool {
 	c, err := net.Dial("tcp", testServer)
@@ -47,7 +44,7 @@ func TestLocalhost(t *testing.T) {
 	if !setup(t) {
 		return
 	}
-	testWithClient(t, New(maxIdleConnsPerAddr, testServer))
+	testWithClient(t, New(testServer))
 }
 
 // Run the memcached binary as a child process and connect to its unix socket.
@@ -69,7 +66,7 @@ func TestUnixSocket(t *testing.T) {
 		time.Sleep(time.Duration(25*i) * time.Millisecond)
 	}
 
-	testWithClient(t, New(maxIdleConnsPerAddr, sock))
+	testWithClient(t, New(sock))
 }
 
 func testWithClient(t *testing.T, c *Client) {


### PR DESCRIPTION
Write a new ‘NewWithConnThreshold’ func to configure maxIdleConnsPerAddr. Decide not to change the original 'New' func in consideration of backward compatibility.
