### PR TITLE
Added DeleteAll() method

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -98,6 +98,7 @@ func legalKey(key string) bool {
 
 var (
 	crlf            = []byte("\r\n")
+	resultOK		= []byte("OK\r\n")
 	resultStored    = []byte("STORED\r\n")
 	resultNotStored = []byte("NOT_STORED\r\n")
 	resultExists    = []byte("EXISTS\r\n")
@@ -518,6 +519,8 @@ func writeExpectf(rw *bufio.ReadWriter, expect []byte, format string, args ...in
 		return err
 	}
 	switch {
+	case bytes.Equal(line, resultOK):
+		return nil
 	case bytes.Equal(line, expect):
 		return nil
 	case bytes.Equal(line, resultNotStored):
@@ -537,6 +540,15 @@ func (c *Client) Delete(key string) error {
 		return writeExpectf(rw, resultDeleted, "delete %s\r\n", key)
 	})
 }
+
+// DeleteAll deletes all items in the cache. 
+func (c *Client) DeleteAll() error {
+	return c.withKeyRw("", func(rw *bufio.ReadWriter) error {
+		return writeExpectf(rw, resultDeleted, "flush_all\r\n")
+	})
+}
+
+
 
 // Increment atomically increments key by delta. The return value is
 // the new value after being incremented or an error. If the value

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -136,7 +136,15 @@ func testWithClient(t *testing.T, c *Client) {
 	if err != ErrCacheMiss {
 		t.Errorf("post-Delete want ErrCacheMiss, got %v", err)
 	}
-
+	
+	// Test Delete All
+	err = c.DeleteAll()
+	checkErr(err, "DeleteAll: %v", err)
+	it, err = c.Get("bar")
+	if err != ErrCacheMiss {
+		t.Errorf("post-DeleteAll want ErrCacheMiss, got %v", err)
+	}
+	
 	// Incr/Decr
 	mustSet(&Item{Key: "num", Value: []byte("42")})
 	n, err := c.Increment("num", 8)
@@ -160,5 +168,5 @@ func testWithClient(t *testing.T, c *Client) {
 	if err == nil || !strings.Contains(err.Error(), "client error") {
 		t.Fatalf("increment non-number: want client error, got %v", err)
 	}
-
+	
 }


### PR DESCRIPTION
Added a DeleteAll() method to complement Delete() using flush_all to flush all entries in the cache.
