### PR TITLE
Make bufferSize&maxIdleConnsPerAddr configurable

### DIFF
--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -228,3 +228,13 @@ func testTouchWithClient(t *testing.T, c *Client) {
 		}
 	}
 }
+
+func TestCreateClientWithOpts(t *testing.T) {
+	client := NewFromSelector(nil, SetBufferSize(3), SetMaxIdleConnsPerAddr(4))
+	if client.bufferSize != 3 {
+		t.Fatalf("set buffer size failure")
+	}
+	if client.maxIdleConnsPerAddr != 4 {
+		t.Fatalf("set max idle conns per addr failure")
+	}
+}


### PR DESCRIPTION
- Add `bufferSize` field to client, add `SetBufferSize` optional function to constructor
- Add `maxIdleConnsPerAddr` field to client, add `SetMaxIdleConnsPerAddr` optional function to constructo
- Fix some lint warning for method comment

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bradfitz/gomemcache/44)
<!-- Reviewable:end -->
