### PR TITLE
Support for older versions of Kestrel using memcache

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -330,7 +330,7 @@ func (c *Client) Get(key string) (item *Item, err error) {
 	if err == nil && item == nil {
 		c.selector.CacheMiss()
 		err = ErrCacheMiss
-	} else {
+	} else if err == nil {
 		c.selector.CacheHit()
 	}
 	return

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -203,6 +203,15 @@ func (c *Client) putFreeConn(addr net.Addr, cn *conn) {
 	c.freeconn[addr.String()] = append(freelist, cn)
 }
 
+// Close all open connections
+func (c *Client) Close() {
+	for _, freelist := range c.freeconn {
+		for _, conn := range freelist {
+			conn.nc.Close()
+		}
+	}
+}
+
 func (c *Client) getFreeConn(addr net.Addr) (cn *conn, ok bool) {
 	c.lk.Lock()
 	defer c.lk.Unlock()

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -196,13 +196,8 @@ func (c *Client) UpdateServerList(server ...string) {
 	// connections behind for servers that are no longer in the list
 	c.lk.Lock()
 	defer c.lk.Unlock()
-
-	newSelector := new(RRServerList)
-	newSelector.SetServers(server...)
-
+	c.selector.SetServers(server...)
 	c.closeUnlocked()
-
-	c.selector = newSelector
 }
 
 func (c *Client) putFreeConn(addr net.Addr, cn *conn) {

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -116,7 +116,7 @@ var (
 // with equal weight. If a server is listed multiple times,
 // it gets a proportional amount of weight.
 func New(server ...string) *Client {
-	ss := new(ServerList)
+	ss := new(RRServerList)
 	ss.SetServers(server...)
 	return NewFromSelector(ss)
 }

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -689,3 +689,11 @@ func (c *Client) incrDecr(verb, key string, delta uint64) (uint64, error) {
 	})
 	return val, err
 }
+
+func (c *Client) CacheMiss() {
+	c.selector.CacheMiss()
+}
+
+func (c *Client) CacheHit() {
+	c.selector.CacheHit()
+}

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -337,6 +337,10 @@ func (c *Client) Get(key string) (item *Item, err error) {
 		err = ErrCacheMiss
 	} else if err == nil {
 		c.selector.CacheHit()
+	} else if err != nil {
+		// Record a cache miss for misbehaving servers to take them out of the
+		// rotation
+		c.selector.CacheMiss()
 	}
 	return
 }

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -311,7 +311,10 @@ func (c *Client) Get(key string) (item *Item, err error) {
 		return c.getFromAddrSingle(addr, key, func(it *Item) { item = it })
 	})
 	if err == nil && item == nil {
+		c.selector.CacheMiss()
 		err = ErrCacheMiss
+	} else {
+		c.selector.CacheHit()
 	}
 	return
 }
@@ -688,12 +691,4 @@ func (c *Client) incrDecr(verb, key string, delta uint64) (uint64, error) {
 		return nil
 	})
 	return val, err
-}
-
-func (c *Client) CacheMiss() {
-	c.selector.CacheMiss()
-}
-
-func (c *Client) CacheHit() {
-	c.selector.CacheHit()
 }

--- a/memcache/rr_selector.go
+++ b/memcache/rr_selector.go
@@ -113,6 +113,7 @@ func (rrsl *RRServerList) PickServer(key string) (net.Addr, error) {
 func (rrsl *RRServerList) CacheMiss() {
 	rrsl.lastServer.missCount++
 	if rrsl.lastServer.missCount >= missCount {
+		rrsl.lastServer.missCount = missCount
 		rrsl.lastServer.skipDeadline = time.Now().Add(skipTime)
 	}
 }

--- a/memcache/rr_selector.go
+++ b/memcache/rr_selector.go
@@ -93,6 +93,7 @@ func (rrsl *RRServerList) PickServer(key string) (net.Addr, error) {
 			found = true
 			rrsl.lastIndex = index
 		}
+		index++
 	}
 
 	if !found {

--- a/memcache/rr_selector.go
+++ b/memcache/rr_selector.go
@@ -10,13 +10,24 @@ import (
 
 const (
 	missCount      = 3               // Number of times we allow a server to get a cache miss before we start skipping it
+	errCount       = 3               // Number of times we allow a server to run into error before we start skipping it
 	skipTimeBase   = time.Second * 5 // Time delay until we retry the server again
 	extraWaitRange = 3               // Randomize the delay a little bit between clients to prevent the thundering herd problem
 )
 
 type rrServer struct {
-	addr         net.Addr
-	missCount    int // Consecutive number of misses on this particular server
+	addr           net.Addr
+	missCount      int // Consecutive number of misses on this particular server
+	errCount       int
+	skipDeadline   time.Time
+	lastQueueIndex int
+	lastQueue      *rrQueue
+	queues         []rrQueue
+}
+
+type rrQueue struct {
+	keyIndex     int
+	missCount    int // Consecutive number of misses on this particular queue
 	skipDeadline time.Time
 }
 
@@ -25,6 +36,7 @@ type RRServerList struct {
 	servers    []rrServer
 	lastIndex  int
 	lastServer *rrServer
+	keys       []string
 }
 
 func (rrsl *RRServerList) SetServers(servers ...string) error {
@@ -50,13 +62,43 @@ func (rrsl *RRServerList) SetServers(servers ...string) error {
 	rrsl.servers = rrServers
 	rrsl.lastIndex = 0
 	rrsl.lastServer = nil
+
+	if len(rrsl.keys) > 0 {
+		rrsl.SetQueuesUnlocked(rrsl.keys)
+	}
 	return nil
+}
+
+func (rrsl *RRServerList) SetQueues(queues ...string) {
+	rrsl.mu.Lock()
+	defer rrsl.mu.Unlock()
+
+	rrsl.SetQueuesUnlocked(queues)
+}
+
+func (rrsl *RRServerList) SetQueuesUnlocked(queues []string) {
+	rrsl.keys = queues
+	for i := 0; i < len(rrsl.servers); i++ {
+		rrsl.servers[i].queues = make([]rrQueue, 0, len(rrsl.keys))
+		for j := 0; j < len(rrsl.keys); j++ {
+			queue := rrQueue{
+				keyIndex:  j,
+				missCount: 0,
+			}
+			rrsl.servers[i].queues = append(rrsl.servers[i].queues, queue)
+			rrsl.servers[i].lastQueueIndex = 0
+			rrsl.servers[i].lastQueue = nil
+		}
+	}
+}
+
+func (rrsl *RRServerList) GetQueues() []string {
+	return rrsl.keys
 }
 
 func (rrsl *RRServerList) Each(f func(net.Addr) error) error {
 	rrsl.mu.RLock()
 	defer rrsl.mu.RUnlock()
-
 	for _, server := range rrsl.servers {
 		err := f(server.addr)
 		if err != nil {
@@ -65,6 +107,78 @@ func (rrsl *RRServerList) Each(f func(net.Addr) error) error {
 	}
 
 	return nil
+}
+
+func (rrsl *RRServerList) PickQueue() (net.Addr, string, error) {
+	rrsl.mu.Lock()
+	defer rrsl.mu.Unlock()
+
+	// All servers should have exactly the same queue list
+	// so we only need to check the first server here
+	if len(rrsl.servers) == 0 || len(rrsl.servers[0].queues) == 0 {
+		return nil, "", ErrNoServers
+	}
+
+	// Start from the last server because we don't want to starve
+	// out the other queues every time there's a hit on this server
+	index := rrsl.lastIndex
+	for {
+		server := &rrsl.servers[index]
+		if server.errCount >= errCount && time.Now().Before(server.skipDeadline) {
+			// The current server is misbehaving, skip it and check the other servers
+			index++
+			if index >= len(rrsl.servers) {
+				index = 0
+			}
+			if index == rrsl.lastIndex {
+				break
+			}
+			continue
+		}
+
+		// Next pick a queue for this server
+		queueFound := false
+		queueIndex := server.lastQueueIndex + 1
+		for !queueFound {
+			if queueIndex >= len(server.queues) {
+				queueIndex = 0
+			}
+			queue := &server.queues[queueIndex]
+			if queue.missCount >= missCount {
+				if time.Now().After(queue.skipDeadline) {
+					queueFound = true
+					rrsl.lastIndex = index
+					server.lastQueueIndex = queueIndex
+				}
+			} else {
+				queueFound = true
+				rrsl.lastIndex = index
+				server.lastQueueIndex = queueIndex
+			}
+			queueIndex++
+			if queueIndex == server.lastQueueIndex+1 {
+				break
+			}
+		}
+		if !queueFound {
+			// This server doesn't have an available queue
+			// Check the other servers
+			index++
+			if index >= len(rrsl.servers) {
+				index = 0
+			}
+			if index == rrsl.lastIndex {
+				break
+			}
+			continue
+		}
+		rrsl.lastServer = &rrsl.servers[rrsl.lastIndex]
+		server.lastQueue = &server.queues[server.lastQueueIndex]
+
+		return server.addr, rrsl.keys[server.lastQueue.keyIndex], nil
+	}
+
+	return nil, "", ErrNoServers
 }
 
 func (rrsl *RRServerList) PickServer(key string) (net.Addr, error) {
@@ -130,4 +244,43 @@ func (rrsl *RRServerList) CacheMiss() {
 // Record a cache hit on the server to put it back in the regular rotation
 func (rrsl *RRServerList) CacheHit() {
 	rrsl.lastServer.missCount = 0
+}
+
+func (rrsl *RRServerList) QueueCacheMiss() {
+	if rrsl.lastServer == nil || rrsl.lastServer.lastQueue == nil {
+		return
+	}
+
+	rrsl.lastServer.errCount = 0
+	rrsl.lastServer.lastQueue.missCount++
+	if rrsl.lastServer.lastQueue.missCount >= missCount {
+		rrsl.lastServer.lastQueue.missCount = missCount
+		// When we set the deadline randomize it a bit per client so that all
+		// thread's don't wake up around the same time and hammer the servers
+		extraWait := time.Duration(rand.Int31n(extraWaitRange))
+		rrsl.lastServer.lastQueue.skipDeadline = time.Now().Add(skipTimeBase + time.Second*extraWait)
+	}
+}
+
+func (rrsl *RRServerList) QueueCacheHit() {
+	rrsl.lastServer.lastQueue.missCount = 0
+	rrsl.lastServer.errCount = 0
+}
+
+func (rrsl *RRServerList) ServerMisbehaving() {
+	if rrsl.lastServer == nil {
+		return
+	}
+
+	rrsl.lastServer.errCount++
+	if rrsl.lastServer.errCount >= errCount {
+		rrsl.lastServer.errCount = errCount
+		extraWait := time.Duration(rand.Int31n(extraWaitRange))
+		rrsl.lastServer.skipDeadline = time.Now().Add(skipTimeBase + time.Second*extraWait)
+	}
+}
+
+func (rrsl *RRServerList) GetCurrQueue() (net.Addr, string) {
+	currQueue := rrsl.lastServer.lastQueue
+	return rrsl.lastServer.addr, rrsl.keys[currQueue.keyIndex]
 }

--- a/memcache/rr_selector.go
+++ b/memcache/rr_selector.go
@@ -78,10 +78,9 @@ func (rrsl *RRServerList) PickServer(key string) (net.Addr, error) {
 
 	found := false
 	index := rrsl.lastIndex + 1
-	for index != rrsl.lastIndex && !found {
+	for !found {
 		if index >= len(rrsl.servers) {
 			index = 0
-			continue
 		}
 		server := &rrsl.servers[index]
 		if server.missCount >= missCount {
@@ -94,6 +93,9 @@ func (rrsl *RRServerList) PickServer(key string) (net.Addr, error) {
 			rrsl.lastIndex = index
 		}
 		index++
+		if index == rrsl.lastIndex+1 {
+			break
+		}
 	}
 
 	if !found {

--- a/memcache/rr_selector.go
+++ b/memcache/rr_selector.go
@@ -6,34 +6,45 @@ import (
 	"sync"
 )
 
+const (
+	missCount = 3   // Number of times we allow a server to get a cache miss before we start skipping it
+	skipCount = 100 // Number of times to skip over this server in the selector before we try again
+)
+
+type rrServer struct {
+	addr      net.Addr
+	missCount int // Consecutive number of misses on this particular server
+	skipCount int // Number of times we've skipped this server in the selector
+}
+
 type RRServerList struct {
-	mu		   sync.RWMutex
-	addrs	   []net.Addr
+	mu         sync.RWMutex
+	servers    []rrServer
 	lastIndex  int
-	lastServer net.Addr
+	lastServer *rrServer
 }
 
 func (rrsl *RRServerList) SetServers(servers ...string) error {
-	naddr := make([]net.Addr, len(servers))
+	rrServers := make([]rrServer, len(servers))
 	for i, server := range servers {
 		if strings.Contains(server, "/") {
 			addr, err := net.ResolveUnixAddr("unix", server)
 			if err != nil {
 				return err
 			}
-			naddr[i] = addr
+			rrServers[i].addr = addr
 		} else {
 			tcpaddr, err := net.ResolveTCPAddr("tcp", server)
 			if err != nil {
 				return err
 			}
-			naddr[i] = tcpaddr
+			rrServers[i].addr = tcpaddr
 		}
 	}
 
 	rrsl.mu.Lock()
 	defer rrsl.mu.Unlock()
-	rrsl.addrs = naddr
+	rrsl.servers = rrServers
 	return nil
 }
 
@@ -41,8 +52,8 @@ func (rrsl *RRServerList) Each(f func(net.Addr) error) error {
 	rrsl.mu.RLock()
 	defer rrsl.mu.RUnlock()
 
-	for _, addr := range rrsl.addrs {
-		err := f(addr)
+	for _, server := range rrsl.servers {
+		err := f(server.addr)
 		if err != nil {
 			return err
 		}
@@ -55,22 +66,57 @@ func (rrsl *RRServerList) PickServer(key string) (net.Addr, error) {
 	rrsl.mu.Lock()
 	defer rrsl.mu.Unlock()
 
-	if len(rrsl.addrs) == 0 {
+	if len(rrsl.servers) == 0 {
 		return nil, ErrNoServers
 	}
-	if len(rrsl.addrs) == 1 {
-		return rrsl.addrs[0], nil
-	}
 	if strings.Contains(key, "/close") && !strings.Contains(key, "/close/open") {
-		return rrsl.lastServer, nil
-	}
-	if rrsl.lastIndex >= len(rrsl.addrs) {
-		rrsl.lastIndex = 0
+		return rrsl.lastServer.addr, nil
 	}
 
-	rrsl.lastServer = rrsl.addrs[rrsl.lastIndex]
-	addr := rrsl.lastServer
+	found := false
+	index := rrsl.lastIndex + 1
+	for index != rrsl.lastIndex && !found {
+		if index >= len(rrsl.servers) {
+			index = 0
+			continue
+		}
+		server := rrsl.servers[index]
+		if server.missCount >= missCount {
+			if server.skipCount >= skipCount {
+				server.skipCount = 0
+				found = true
+				rrsl.lastIndex = index
+			} else {
+				server.skipCount++
+			}
+		} else {
+			found = true
+			rrsl.lastIndex = index
+		}
+	}
+
+	if !found {
+		return nil, ErrNoServers
+	}
+
+	rrsl.lastServer = &rrsl.servers[rrsl.lastIndex]
+	addr := rrsl.lastServer.addr
 	rrsl.lastIndex++
 
 	return addr, nil
+}
+
+// We use both of these functions unlocked anyway since we have to maintain some
+// state for kestrel /open and /close calls for reading. This doesn't affect
+// writing to kestrel
+
+// Record a cache miss for the last server we hit so that we avoid hitting it
+// too often
+func (rrsl *RRServerList) CacheMiss() {
+	rrsl.lastServer.missCount++
+}
+
+// Record a cache hit on the server to put it back in the regular rotation
+func (rrsl *RRServerList) CacheHit() {
+	rrsl.lastServer.missCount = 0
 }

--- a/memcache/rr_selector.go
+++ b/memcache/rr_selector.go
@@ -101,7 +101,6 @@ func (rrsl *RRServerList) PickServer(key string) (net.Addr, error) {
 
 	rrsl.lastServer = &rrsl.servers[rrsl.lastIndex]
 	addr := rrsl.lastServer.addr
-	rrsl.lastIndex++
 
 	return addr, nil
 }

--- a/memcache/rr_selector.go
+++ b/memcache/rr_selector.go
@@ -7,9 +7,10 @@ import (
 )
 
 type RRServerList struct {
-	mu		  sync.RWMutex
-	addrs	  []net.Addr
-	lastIndex int
+	mu		   sync.RWMutex
+	addrs	   []net.Addr
+	lastIndex  int
+	lastServer net.Addr
 }
 
 func (rrsl *RRServerList) SetServers(servers ...string) error {
@@ -61,13 +62,14 @@ func (rrsl *RRServerList) PickServer(key string) (net.Addr, error) {
 		return rrsl.addrs[0], nil
 	}
 	if strings.Contains(key, "/close") && !strings.Contains(key, "/close/open") {
-		return rrsl.addrs[rrsl.lastIndex-1], nil
+		return rrsl.lastServer, nil
 	}
 	if rrsl.lastIndex >= len(rrsl.addrs) {
 		rrsl.lastIndex = 0
 	}
 
-	addr := rrsl.addrs[rrsl.lastIndex]
+	rrsl.lastServer = rrsl.addrs[rrsl.lastIndex]
+	addr := rrsl.lastServer
 	rrsl.lastIndex++
 
 	return addr, nil

--- a/memcache/rr_selector.go
+++ b/memcache/rr_selector.go
@@ -80,7 +80,7 @@ func (rrsl *RRServerList) PickServer(key string) (net.Addr, error) {
 			index = 0
 			continue
 		}
-		server := rrsl.servers[index]
+		server := &rrsl.servers[index]
 		if server.missCount >= missCount {
 			if server.skipCount >= skipCount {
 				server.skipCount = 0

--- a/memcache/rr_selector.go
+++ b/memcache/rr_selector.go
@@ -1,0 +1,74 @@
+package memcache
+
+import (
+	"net"
+	"strings"
+	"sync"
+)
+
+type RRServerList struct {
+	mu		  sync.RWMutex
+	addrs	  []net.Addr
+	lastIndex int
+}
+
+func (rrsl *RRServerList) SetServers(servers ...string) error {
+	naddr := make([]net.Addr, len(servers))
+	for i, server := range servers {
+		if strings.Contains(server, "/") {
+			addr, err := net.ResolveUnixAddr("unix", server)
+			if err != nil {
+				return err
+			}
+			naddr[i] = addr
+		} else {
+			tcpaddr, err := net.ResolveTCPAddr("tcp", server)
+			if err != nil {
+				return err
+			}
+			naddr[i] = tcpaddr
+		}
+	}
+
+	rrsl.mu.Lock()
+	defer rrsl.mu.Unlock()
+	rrsl.addrs = naddr
+	return nil
+}
+
+func (rrsl *RRServerList) Each(f func(net.Addr) error) error {
+	rrsl.mu.RLock()
+	defer rrsl.mu.RUnlock()
+
+	for _, addr := range rrsl.addrs {
+		err := f(addr)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (rrsl *RRServerList) PickServer(key string) (net.Addr, error) {
+	rrsl.mu.Lock()
+	defer rrsl.mu.Unlock()
+
+	if len(rrsl.addrs) == 0 {
+		return nil, ErrNoServers
+	}
+	if len(rrsl.addrs) == 1 {
+		return rrsl.addrs[0], nil
+	}
+	if strings.Contains(key, "/close") && !strings.Contains(key, "/close/open") {
+		return rrsl.addrs[rrsl.lastIndex-1], nil
+	}
+	if rrsl.lastIndex >= len(rrsl.addrs) {
+		rrsl.lastIndex = 0
+	}
+
+	addr := rrsl.addrs[rrsl.lastIndex]
+	rrsl.lastIndex++
+
+	return addr, nil
+}

--- a/memcache/rr_selector.go
+++ b/memcache/rr_selector.go
@@ -48,6 +48,8 @@ func (rrsl *RRServerList) SetServers(servers ...string) error {
 	rrsl.mu.Lock()
 	defer rrsl.mu.Unlock()
 	rrsl.servers = rrServers
+	rrsl.lastIndex = 0
+	rrsl.lastServer = nil
 	return nil
 }
 

--- a/memcache/rr_selector_test.go
+++ b/memcache/rr_selector_test.go
@@ -1,0 +1,194 @@
+package memcache
+
+import (
+	"testing"
+)
+
+func TestServerMisBehaving(t *testing.T) {
+	servers := []string{"localhost:22133"}
+	queue := []string{"ns__queueName__env", "ns__queueName__subq__env"}
+
+	client, err := NewWithQueues(servers, queue)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	for i := 0; i < errCount; i++ {
+		addr, _, err := client.selector.PickQueue()
+		if err != nil {
+			t.Errorf("Unexpected err=%s\n", err.Error())
+		}
+
+		client.selector.ServerMisbehaving()
+	}
+	_, _, err = client.selector.PickQueue()
+
+	if err != ErrNoServers {
+		t.Error("Failed to return ErrNoServers error")
+	}
+}
+
+func TestErrNoServersSingle(t *testing.T) {
+	servers := []string{"localhost:22133"}
+	queue := []string{"ns__queueName__env"}
+	client, err := NewWithQueues(servers, queue)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	for i := 0; i < missCount; i++ {
+		_, _, err := client.selector.PickQueue()
+		if err != nil {
+			t.Errorf("Unexpected err=%s\n", err.Error())
+		}
+		client.selector.QueueCacheMiss()
+	}
+
+	_, _, err = client.selector.PickQueue()
+
+	if err != ErrNoServers {
+		t.Error("Failed to return ErrNoServers error")
+	}
+}
+
+func TestErrNoServers(t *testing.T) {
+	servers := []string{"localhost:22133", "localhost:22134"}
+	queue := []string{"ns__queueName__env", "ns__queueName__subq__env"}
+	client, err := NewWithQueues(servers, queue)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	for i := 0; i < missCount*4; i++ {
+		_, _, err := client.selector.PickQueue()
+		if err != nil {
+			t.Errorf("Unexpected err=%s\n", err.Error())
+		}
+		client.selector.QueueCacheMiss()
+	}
+
+	_, _, err = client.selector.PickQueue()
+
+	if err != ErrNoServers {
+		t.Error("Failed to return ErrNoServers")
+	}
+}
+
+func TestNoMissSingle(t *testing.T) {
+	servers := []string{"localhost:22133"}
+	queue := []string{"ns__queueName__env"}
+	client, err := NewWithQueues(servers, queue)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	for i := 0; i < missCount-1; i++ {
+		_, _, err := client.selector.PickQueue()
+		if err != nil {
+			t.Errorf("Unexpected err=%s\n", err.Error())
+		}
+		client.selector.QueueCacheMiss()
+	}
+
+	_, _, err = client.selector.PickQueue()
+
+	if err != nil {
+		t.Errorf("Unexpected err=%s\n", err.Error())
+	}
+}
+
+func TestNoMiss(t *testing.T) {
+	servers := []string{"localhost:22133", "localhost:22134"}
+	queue := []string{"ns__queueName__env", "ns__queueName__subq__env"}
+	client, err := NewWithQueues(servers, queue)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	for i := 0; i < missCount*4-1; i++ {
+		_, _, err := client.selector.PickQueue()
+		if err != nil {
+			t.Errorf("Unexpected err=%s\n", err.Error())
+		}
+		client.selector.QueueCacheMiss()
+	}
+
+	_, _, err = client.selector.PickQueue()
+
+	if err != nil {
+		t.Errorf("Unexpected err=%s\n", err.Error())
+	}
+}
+
+func TestNoMissWithHit(t *testing.T) {
+	servers := []string{"localhost:22133", "localhost:22134"}
+	queue := []string{"ns__queueName__env", "ns__queueName__subq__env"}
+	client, err := NewWithQueues(servers, queue)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	for i := 0; i < missCount*4-1; i++ {
+		_, _, err := client.selector.PickQueue()
+		if err != nil {
+			t.Errorf("Unexpected err=%s\n", err.Error())
+		}
+		client.selector.QueueCacheMiss()
+	}
+
+	client.selector.PickQueue()
+	client.selector.QueueCacheHit()
+	_, _, err = client.selector.PickQueue()
+
+	if err != nil {
+		t.Errorf("Unexpected err=%s\n", err.Error())
+	}
+}
+
+func TestQueueOrder(t *testing.T) {
+	servers := []string{"localhost:22133"}
+	queue := []string{"ns__queueName__env", "ns__queueName__subq__env"}
+
+	client, err := NewWithQueues(servers, queue)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	//t.Logf("queues=%v\n", client.selector.GetQueues())
+
+	for i := 0; i < 4; i++ {
+		_, key, err := client.selector.PickQueue()
+		if err != nil {
+			t.Errorf("Unexpected err=%s\n", err.Error())
+		}
+
+		// We select lastQueueIndex+1
+		if key != queue[(i+1)%2] {
+			t.Errorf("Expected queue=%s, but get queue=%s\n", queue[i%2], key)
+		}
+
+		client.selector.QueueCacheHit()
+	}
+}
+
+func TestServerOrder(t *testing.T) {
+	servers := []string{"localhost:22133", "localhost:22134"}
+	queue := []string{"ns__queueName__env", "ns__queueName__subq__env"}
+
+	client, err := NewWithQueues(servers, queue)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	for i := 0; i < missCount*len(queue); i++ {
+		addr, _, err := client.selector.PickQueue()
+		if err != nil {
+			t.Errorf("Unexpected err=%s\n", err.Error())
+		}
+
+		if addr.String() != "127.0.0.1:22133" {
+			t.Errorf("Picked server=%s, expected=127.0.0.1:22133\n", addr.String())
+		}
+		client.selector.QueueCacheHit()
+	}
+}

--- a/memcache/selector.go
+++ b/memcache/selector.go
@@ -33,9 +33,17 @@ type ServerSelector interface {
 	// should be shared onto.
 	SetServers(servers ...string) error
 	PickServer(key string) (net.Addr, error)
+	// Returns server address, queue name and error
+	PickQueue() (net.Addr, string, error)
 	Each(func(net.Addr) error) error
 	CacheMiss()
 	CacheHit()
+	QueueCacheMiss()
+	QueueCacheHit()
+	SetQueues(queues ...string)
+	GetCurrQueue() (net.Addr, string)
+	GetQueues() []string
+	ServerMisbehaving()
 }
 
 // ServerList is a simple ServerSelector. Its zero value is usable.
@@ -117,5 +125,12 @@ func (ss *ServerList) PickServer(key string) (net.Addr, error) {
 }
 
 // No-ops in this selector
-func (ss *ServerList) CacheHit()  {}
-func (ss *ServerList) CacheMiss() {}
+func (ss *ServerList) CacheHit()                            {}
+func (ss *ServerList) CacheMiss()                           {}
+func (ss *ServerList) QueueCacheHit()                       {}
+func (ss *ServerList) QueueCacheMiss()                      {}
+func (ss *ServerList) SetQueues(queues ...string)           {}
+func (ss *ServerList) GetCurrQueue() (net.Addr, string)     { return nil, "" }
+func (ss *ServerList) PickQueue() (net.Addr, string, error) { return nil, "", nil }
+func (ss *ServerList) GetQueues() []string                  { return nil }
+func (ss *ServerList) ServerMisbehaving()                   {}

--- a/memcache/selector.go
+++ b/memcache/selector.go
@@ -31,6 +31,7 @@ import (
 type ServerSelector interface {
 	// PickServer returns the server address that a given item
 	// should be shared onto.
+	SetServers(servers ...string) error
 	PickServer(key string) (net.Addr, error)
 	Each(func(net.Addr) error) error
 	CacheMiss()

--- a/memcache/selector.go
+++ b/memcache/selector.go
@@ -33,6 +33,8 @@ type ServerSelector interface {
 	// should be shared onto.
 	PickServer(key string) (net.Addr, error)
 	Each(func(net.Addr) error) error
+	CacheMiss()
+	CacheHit()
 }
 
 // ServerList is a simple ServerSelector. Its zero value is usable.
@@ -112,3 +114,7 @@ func (ss *ServerList) PickServer(key string) (net.Addr, error) {
 
 	return ss.addrs[cs%uint32(len(ss.addrs))], nil
 }
+
+// No-ops in this selector
+func (ss *ServerList) CacheHit()  {}
+func (ss *ServerList) CacheMiss() {}

--- a/memcache/selector.go
+++ b/memcache/selector.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	 http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -37,9 +37,8 @@ type ServerSelector interface {
 
 // ServerList is a simple ServerSelector. Its zero value is usable.
 type ServerList struct {
-	mu		   sync.RWMutex
-	addrs	   []net.Addr
-	lastServer net.Addr
+	mu    sync.RWMutex
+	addrs []net.Addr
 }
 
 // SetServers changes a ServerList's set of servers at runtime and is
@@ -72,7 +71,6 @@ func (ss *ServerList) SetServers(servers ...string) error {
 	ss.mu.Lock()
 	defer ss.mu.Unlock()
 	ss.addrs = naddr
-	ss.lastServer = ss.addrs[0]
 	return nil
 }
 
@@ -101,12 +99,6 @@ var keyBufPool = sync.Pool{
 func (ss *ServerList) PickServer(key string) (net.Addr, error) {
 	ss.mu.RLock()
 	defer ss.mu.RUnlock()
-
-	// If we're closing a message return the last server
-	if strings.Contains(key, "/close") {
-		return ss.lastServer, nil
-	}
-
 	if len(ss.addrs) == 0 {
 		return nil, ErrNoServers
 	}
@@ -118,6 +110,5 @@ func (ss *ServerList) PickServer(key string) (net.Addr, error) {
 	cs := crc32.ChecksumIEEE((*bufp)[:n])
 	keyBufPool.Put(bufp)
 
-	ss.lastServer = ss.addrs[cs%uint32(len(ss.addrs))]
-	return ss.lastServer, nil
+	return ss.addrs[cs%uint32(len(ss.addrs))], nil
 }


### PR DESCRIPTION
Older versions of Kestrel using the memcache protocol don't support the GETS command. This patch simply makes it so retrieving single values uses the GET command instead which shouldn't break current usage of memcache.Get().

gofmt was run on the file as well so that's why there's some spacing and indentation changes.
