### PR TITLE
Remove unused struct

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -237,11 +237,6 @@ func (cte *ConnectTimeoutError) Error() string {
 }
 
 func (c *Client) dial(addr net.Addr) (net.Conn, error) {
-	type connError struct {
-		cn  net.Conn
-		err error
-	}
-
 	nc, err := net.DialTimeout(addr.Network(), addr.String(), c.netTimeout())
 	if err == nil {
 		return nc, nil


### PR DESCRIPTION
connError is unused after d919402
