### PR TITLE
Speed up scanning memcache responses, increase throughput.

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -515,7 +515,7 @@ func scanGetResponseLine(line []byte, it *Item) (size int, err error) {
 	// dest := []interface{}{&it.Key, &it.Flags, &size, &it.casid}
 	partsCount := len(parts)
 	if partsCount < 3 || partsCount > 4 {
-		return -1, fmt.Errorf("Expected line to match %s %s %d [%d]: got %q", line)
+		return -1, fmt.Errorf("Expected line to match %%s %%s %%d [%%d]: got %q", line)
 	}
 	// "%s %d %d\n"
 	it.Key = string(parts[0])


### PR DESCRIPTION
The Sscanf was revealed as being CPU intensive by the -cpuprofile option
(It has to use reflection to know what to parse?)

```
export GOMAXPROCS=4;
go test -run='^$' -bench SetGet -benchtime 5s
```

Before this change: BenchmarkSetGet-4 200000 50299 ns/op
After this change:  BenchmarkSetGet-4 200000 45301 ns/op