### PR TITLE
Remove a seemingly unnecessary indirection layer

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -192,8 +192,8 @@ func (cn *conn) extendDeadline() {
 // is nil (not an error) or is only a protocol level error (e.g. a
 // cache miss).  The purpose is to not recycle TCP connections that
 // are bad.
-func (cn *conn) condRelease(err *error) {
-	if *err == nil || resumableError(*err) {
+func (cn *conn) condRelease(err error) {
+	if err == nil || resumableError(err) {
 		cn.release()
 	} else {
 		cn.nc.Close()
@@ -301,7 +301,7 @@ func (c *Client) onItem(item *Item, fn func(*Client, *bufio.ReadWriter, *Item) e
 	if err != nil {
 		return err
 	}
-	defer cn.condRelease(&err)
+	defer cn.condRelease(err)
 	if err = fn(c, cn.rw, item); err != nil {
 		return err
 	}
@@ -350,7 +350,7 @@ func (c *Client) withAddrRw(addr net.Addr, fn func(*bufio.ReadWriter) error) (er
 	if err != nil {
 		return err
 	}
-	defer cn.condRelease(&err)
+	defer cn.condRelease(err)
 	return fn(cn.rw)
 }
 


### PR DESCRIPTION
`err error` seems to be more conventional than `err *error`.
The performance impact is expected to be negligible.