### PR TITLE
memcache: instrument for tracing and metrics with OpenCensus

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -20,6 +20,7 @@ package memcache
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -30,6 +31,11 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/trace"
 )
 
 // Similar to:
@@ -254,7 +260,7 @@ func (cte *ConnectTimeoutError) Error() string {
 	return "memcache: connect timeout to " + cte.Addr.String()
 }
 
-func (c *Client) dial(addr net.Addr) (net.Conn, error) {
+func (c *Client) dial(ctx context.Context, addr net.Addr) (net.Conn, error) {
 	type connError struct {
 		cn  net.Conn
 		err error
@@ -272,14 +278,22 @@ func (c *Client) dial(addr net.Addr) (net.Conn, error) {
 	return nil, err
 }
 
-func (c *Client) getConn(addr net.Addr) (*conn, error) {
+func (c *Client) getConn(ctx context.Context, addr net.Addr) (*conn, error) {
+	ctx, span := trace.StartSpan(ctx, "memcache.(*Client).getConn")
+	defer span.End()
+
+	span.Annotate(nil, "Getting a free connection")
 	cn, ok := c.getFreeConn(addr)
+	span.Annotate(nil, "Finished getting a free connection")
 	if ok {
 		cn.extendDeadline()
 		return cn, nil
 	}
-	nc, err := c.dial(addr)
+	span.Annotate(nil, "Dialing the address")
+	nc, err := c.dial(ctx, addr)
+	span.Annotate(nil, "Finished dialing the address")
 	if err != nil {
+		stats.Record(ctx, mDialErrors.M(1))
 		return nil, err
 	}
 	cn = &conn{
@@ -288,38 +302,63 @@ func (c *Client) getConn(addr net.Addr) (*conn, error) {
 		rw:   bufio.NewReadWriter(bufio.NewReader(nc), bufio.NewWriter(nc)),
 		c:    c,
 	}
+	span.Annotate(nil, "Extending the connection's deadline")
 	cn.extendDeadline()
+	span.Annotate(nil, "Finished extending the connection's deadline")
 	return cn, nil
 }
 
-func (c *Client) onItem(item *Item, fn func(*Client, *bufio.ReadWriter, *Item) error) error {
+func (c *Client) onItem(ctx context.Context, item *Item, fn func(*Client, context.Context, *bufio.ReadWriter, *Item) error) error {
+	ctx, span := trace.StartSpan(ctx, "memcache.(*Client).onItem")
+	defer span.End()
+
+	span.Annotate([]trace.Attribute{
+		trace.StringAttribute("key", item.Key),
+	}, "Picking a server")
 	addr, err := c.selector.PickServer(item.Key)
 	if err != nil {
+		span.SetStatus(trace.Status{Code: int32(codes.Unknown), Message: err.Error()})
 		return err
 	}
-	cn, err := c.getConn(addr)
+	span.Annotate(nil, "Successfully picked a server")
+
+	span.Annotate(nil, "Getting a connection")
+	cn, err := c.getConn(ctx, addr)
 	if err != nil {
+		span.SetStatus(trace.Status{Code: int32(codes.Unknown), Message: err.Error()})
 		return err
 	}
 	defer cn.condRelease(&err)
-	if err = fn(c, cn.rw, item); err != nil {
+
+	span.Annotate(nil, "Successfully got a connection")
+	if err = fn(c, ctx, cn.rw, item); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (c *Client) FlushAll() error {
-	return c.selector.Each(c.flushAllFromAddr)
+func (c *Client) FlushAll(ctx context.Context) error {
+	ctx, span := trace.StartSpan(ctx, "memcache.(*Client).FlushAll")
+	defer span.End()
+
+	return c.selector.Each(ctx, c.flushAllFromAddr)
 }
 
 // Get gets the item for the given key. ErrCacheMiss is returned for a
 // memcache cache miss. The key must be at most 250 bytes in length.
-func (c *Client) Get(key string) (item *Item, err error) {
-	err = c.withKeyAddr(key, func(addr net.Addr) error {
-		return c.getFromAddr(addr, []string{key}, func(it *Item) { item = it })
+func (c *Client) Get(ctx context.Context, key string) (item *Item, err error) {
+	ctx, span := trace.StartSpan(ctx, "memcache.(*Client).Get")
+	defer span.End()
+
+	err = c.withKeyAddr(ctx, key, func(addr net.Addr) error {
+		return c.getFromAddr(ctx, addr, []string{key}, func(it *Item) { item = it })
 	})
 	if err == nil && item == nil {
 		err = ErrCacheMiss
+		span.SetStatus(trace.Status{Code: int32(codes.NotFound), Message: ErrCacheMiss.Error()})
+		stats.Record(ctx, mCacheMisses.M(1))
+	} else if item != nil {
+		stats.Record(ctx, mCacheHits.M(1))
 	}
 	return
 }
@@ -328,14 +367,18 @@ func (c *Client) Get(key string) (item *Item, err error) {
 // a Unix timestamp or, if seconds is less than 1 month, the number of seconds
 // into the future at which time the item will expire. ErrCacheMiss is returned if the
 // key is not in the cache. The key must be at most 250 bytes in length.
-func (c *Client) Touch(key string, seconds int32) (err error) {
-	return c.withKeyAddr(key, func(addr net.Addr) error {
-		return c.touchFromAddr(addr, []string{key}, seconds)
+func (c *Client) Touch(ctx context.Context, key string, seconds int32) (err error) {
+	ctx, span := trace.StartSpan(ctx, "memcache.(*Client).Touch")
+	defer span.End()
+
+	return c.withKeyAddr(ctx, key, func(addr net.Addr) error {
+		return c.touchFromAddr(ctx, addr, []string{key}, seconds)
 	})
 }
 
-func (c *Client) withKeyAddr(key string, fn func(net.Addr) error) (err error) {
+func (c *Client) withKeyAddr(ctx context.Context, key string, fn func(net.Addr) error) (err error) {
 	if !legalKey(key) {
+		stats.Record(ctx, mIllegalKeys.M(1))
 		return ErrMalformedKey
 	}
 	addr, err := c.selector.PickServer(key)
@@ -345,8 +388,8 @@ func (c *Client) withKeyAddr(key string, fn func(net.Addr) error) (err error) {
 	return fn(addr)
 }
 
-func (c *Client) withAddrRw(addr net.Addr, fn func(*bufio.ReadWriter) error) (err error) {
-	cn, err := c.getConn(addr)
+func (c *Client) withAddrRw(ctx context.Context, addr net.Addr, fn func(*bufio.ReadWriter) error) (err error) {
+	cn, err := c.getConn(ctx, addr)
 	if err != nil {
 		return err
 	}
@@ -354,21 +397,24 @@ func (c *Client) withAddrRw(addr net.Addr, fn func(*bufio.ReadWriter) error) (er
 	return fn(cn.rw)
 }
 
-func (c *Client) withKeyRw(key string, fn func(*bufio.ReadWriter) error) error {
-	return c.withKeyAddr(key, func(addr net.Addr) error {
-		return c.withAddrRw(addr, fn)
+func (c *Client) withKeyRw(ctx context.Context, key string, fn func(*bufio.ReadWriter) error) error {
+	return c.withKeyAddr(ctx, key, func(addr net.Addr) error {
+		return c.withAddrRw(ctx, addr, fn)
 	})
 }
 
-func (c *Client) getFromAddr(addr net.Addr, keys []string, cb func(*Item)) error {
-	return c.withAddrRw(addr, func(rw *bufio.ReadWriter) error {
+func (c *Client) getFromAddr(ctx context.Context, addr net.Addr, keys []string, cb func(*Item)) error {
+	ctx, span := trace.StartSpan(ctx, "memcache.(*Client).getFromAddr")
+	defer span.End()
+
+	return c.withAddrRw(ctx, addr, func(rw *bufio.ReadWriter) error {
 		if _, err := fmt.Fprintf(rw, "gets %s\r\n", strings.Join(keys, " ")); err != nil {
 			return err
 		}
 		if err := rw.Flush(); err != nil {
 			return err
 		}
-		if err := parseGetResponse(rw.Reader, cb); err != nil {
+		if err := parseGetResponse(ctx, rw.Reader, cb); err != nil {
 			return err
 		}
 		return nil
@@ -376,8 +422,8 @@ func (c *Client) getFromAddr(addr net.Addr, keys []string, cb func(*Item)) error
 }
 
 // flushAllFromAddr send the flush_all command to the given addr
-func (c *Client) flushAllFromAddr(addr net.Addr) error {
-	return c.withAddrRw(addr, func(rw *bufio.ReadWriter) error {
+func (c *Client) flushAllFromAddr(ctx context.Context, addr net.Addr) error {
+	return c.withAddrRw(ctx, addr, func(rw *bufio.ReadWriter) error {
 		if _, err := fmt.Fprintf(rw, "flush_all\r\n"); err != nil {
 			return err
 		}
@@ -398,8 +444,8 @@ func (c *Client) flushAllFromAddr(addr net.Addr) error {
 	})
 }
 
-func (c *Client) touchFromAddr(addr net.Addr, keys []string, expiration int32) error {
-	return c.withAddrRw(addr, func(rw *bufio.ReadWriter) error {
+func (c *Client) touchFromAddr(ctx context.Context, addr net.Addr, keys []string, expiration int32) error {
+	return c.withAddrRw(ctx, addr, func(rw *bufio.ReadWriter) error {
 		for _, key := range keys {
 			if _, err := fmt.Fprintf(rw, "touch %s %d\r\n", key, expiration); err != nil {
 				return err
@@ -428,7 +474,12 @@ func (c *Client) touchFromAddr(addr net.Addr, keys []string, expiration int32) e
 // items may have fewer elements than the input slice, due to memcache
 // cache misses. Each key must be at most 250 bytes in length.
 // If no error is returned, the returned map will also be non-nil.
-func (c *Client) GetMulti(keys []string) (map[string]*Item, error) {
+func (c *Client) GetMulti(ctx context.Context, keys []string) (map[string]*Item, error) {
+	ctx, span := trace.StartSpan(ctx, "memcache.(*Client).GetMulti")
+	defer span.End()
+
+	span.Annotate([]trace.Attribute{trace.Int64Attribute("key_count", int64(len(keys)))}, "Getting multi")
+
 	var lk sync.Mutex
 	m := make(map[string]*Item)
 	addItemToMap := func(it *Item) {
@@ -440,6 +491,7 @@ func (c *Client) GetMulti(keys []string) (map[string]*Item, error) {
 	keyMap := make(map[net.Addr][]string)
 	for _, key := range keys {
 		if !legalKey(key) {
+			stats.Record(ctx, mIllegalKeys.M(1))
 			return nil, ErrMalformedKey
 		}
 		addr, err := c.selector.PickServer(key)
@@ -452,7 +504,7 @@ func (c *Client) GetMulti(keys []string) (map[string]*Item, error) {
 	ch := make(chan error, buffered)
 	for addr, keys := range keyMap {
 		go func(addr net.Addr, keys []string) {
-			ch <- c.getFromAddr(addr, keys, addItemToMap)
+			ch <- c.getFromAddr(ctx, addr, keys, addItemToMap)
 		}(addr, keys)
 	}
 
@@ -467,7 +519,10 @@ func (c *Client) GetMulti(keys []string) (map[string]*Item, error) {
 
 // parseGetResponse reads a GET response from r and calls cb for each
 // read and allocated Item
-func parseGetResponse(r *bufio.Reader, cb func(*Item)) error {
+func parseGetResponse(ctx context.Context, r *bufio.Reader, cb func(*Item)) error {
+	_, span := trace.StartSpan(ctx, "memcache.parseGetResponse")
+	defer span.End()
+
 	for {
 		line, err := r.ReadSlice('\n')
 		if err != nil {
@@ -510,32 +565,41 @@ func scanGetResponseLine(line []byte, it *Item) (size int, err error) {
 }
 
 // Set writes the given item, unconditionally.
-func (c *Client) Set(item *Item) error {
-	return c.onItem(item, (*Client).set)
+func (c *Client) Set(ctx context.Context, item *Item) error {
+	ctx, span := trace.StartSpan(ctx, "memcache.(*Client).Set")
+	defer span.End()
+
+	return c.onItem(ctx, item, (*Client).set)
 }
 
-func (c *Client) set(rw *bufio.ReadWriter, item *Item) error {
-	return c.populateOne(rw, "set", item)
+func (c *Client) set(ctx context.Context, rw *bufio.ReadWriter, item *Item) error {
+	return c.populateOne(ctx, rw, "set", item)
 }
 
 // Add writes the given item, if no value already exists for its
 // key. ErrNotStored is returned if that condition is not met.
-func (c *Client) Add(item *Item) error {
-	return c.onItem(item, (*Client).add)
+func (c *Client) Add(ctx context.Context, item *Item) error {
+	ctx, span := trace.StartSpan(ctx, "memcache.(*Client).Add")
+	defer span.End()
+
+	return c.onItem(ctx, item, (*Client).add)
 }
 
-func (c *Client) add(rw *bufio.ReadWriter, item *Item) error {
-	return c.populateOne(rw, "add", item)
+func (c *Client) add(ctx context.Context, rw *bufio.ReadWriter, item *Item) error {
+	return c.populateOne(ctx, rw, "add", item)
 }
 
 // Replace writes the given item, but only if the server *does*
 // already hold data for this key
-func (c *Client) Replace(item *Item) error {
-	return c.onItem(item, (*Client).replace)
+func (c *Client) Replace(ctx context.Context, item *Item) error {
+	ctx, span := trace.StartSpan(ctx, "memcache.(*Client).Replace")
+	defer span.End()
+
+	return c.onItem(ctx, item, (*Client).replace)
 }
 
-func (c *Client) replace(rw *bufio.ReadWriter, item *Item) error {
-	return c.populateOne(rw, "replace", item)
+func (c *Client) replace(ctx context.Context, rw *bufio.ReadWriter, item *Item) error {
+	return c.populateOne(ctx, rw, "replace", item)
 }
 
 // CompareAndSwap writes the given item that was previously returned
@@ -545,16 +609,23 @@ func (c *Client) replace(rw *bufio.ReadWriter, item *Item) error {
 // is returned if the value was modified in between the
 // calls. ErrNotStored is returned if the value was evicted in between
 // the calls.
-func (c *Client) CompareAndSwap(item *Item) error {
-	return c.onItem(item, (*Client).cas)
+func (c *Client) CompareAndSwap(ctx context.Context, item *Item) error {
+	ctx, span := trace.StartSpan(ctx, "memcache.(*Client).CompareAndSwap")
+	defer span.End()
+
+	return c.onItem(ctx, item, (*Client).cas)
 }
 
-func (c *Client) cas(rw *bufio.ReadWriter, item *Item) error {
-	return c.populateOne(rw, "cas", item)
+func (c *Client) cas(ctx context.Context, rw *bufio.ReadWriter, item *Item) error {
+	return c.populateOne(ctx, rw, "cas", item)
 }
 
-func (c *Client) populateOne(rw *bufio.ReadWriter, verb string, item *Item) error {
+func (c *Client) populateOne(ctx context.Context, rw *bufio.ReadWriter, verb string, item *Item) error {
+	ctx, span := trace.StartSpan(ctx, "memcache.(*Client).populateOne")
+	defer span.End()
+
 	if !legalKey(item.Key) {
+		stats.Record(ctx, mIllegalKeys.M(1))
 		return ErrMalformedKey
 	}
 	var err error
@@ -568,15 +639,19 @@ func (c *Client) populateOne(rw *bufio.ReadWriter, verb string, item *Item) erro
 	if err != nil {
 		return err
 	}
+	span.Annotate([]trace.Attribute{}, "Writing item.Value")
 	if _, err = rw.Write(item.Value); err != nil {
 		return err
 	}
+	span.Annotate([]trace.Attribute{}, "Writing CRLF")
 	if _, err := rw.Write(crlf); err != nil {
 		return err
 	}
+	span.Annotate([]trace.Attribute{}, "Flushing")
 	if err := rw.Flush(); err != nil {
 		return err
 	}
+	span.Annotate([]trace.Attribute{}, "Reading a line until we hit a newline")
 	line, err := rw.ReadSlice('\n')
 	if err != nil {
 		return err
@@ -585,13 +660,18 @@ func (c *Client) populateOne(rw *bufio.ReadWriter, verb string, item *Item) erro
 	case bytes.Equal(line, resultStored):
 		return nil
 	case bytes.Equal(line, resultNotStored):
+		stats.Record(ctx, mUnstoredResults.M(1))
 		return ErrNotStored
 	case bytes.Equal(line, resultExists):
+		stats.Record(ctx, mCASConflicts.M(1))
 		return ErrCASConflict
 	case bytes.Equal(line, resultNotFound):
+		stats.Record(ctx, mCacheMisses.M(1))
 		return ErrCacheMiss
+	default:
+		stats.Record(ctx, mClientErrors.M(1))
+		return fmt.Errorf("memcache: unexpected response line from %q: %q", verb, string(line))
 	}
-	return fmt.Errorf("memcache: unexpected response line from %q: %q", verb, string(line))
 }
 
 func writeReadLine(rw *bufio.ReadWriter, format string, args ...interface{}) ([]byte, error) {
@@ -628,15 +708,15 @@ func writeExpectf(rw *bufio.ReadWriter, expect []byte, format string, args ...in
 
 // Delete deletes the item with the provided key. The error ErrCacheMiss is
 // returned if the item didn't already exist in the cache.
-func (c *Client) Delete(key string) error {
-	return c.withKeyRw(key, func(rw *bufio.ReadWriter) error {
+func (c *Client) Delete(ctx context.Context, key string) error {
+	return c.withKeyRw(ctx, key, func(rw *bufio.ReadWriter) error {
 		return writeExpectf(rw, resultDeleted, "delete %s\r\n", key)
 	})
 }
 
 // DeleteAll deletes all items in the cache.
-func (c *Client) DeleteAll() error {
-	return c.withKeyRw("", func(rw *bufio.ReadWriter) error {
+func (c *Client) DeleteAll(ctx context.Context) error {
+	return c.withKeyRw(ctx, "", func(rw *bufio.ReadWriter) error {
 		return writeExpectf(rw, resultDeleted, "flush_all\r\n")
 	})
 }
@@ -646,8 +726,11 @@ func (c *Client) DeleteAll() error {
 // didn't exist in memcached the error is ErrCacheMiss. The value in
 // memcached must be an decimal number, or an error will be returned.
 // On 64-bit overflow, the new value wraps around.
-func (c *Client) Increment(key string, delta uint64) (newValue uint64, err error) {
-	return c.incrDecr("incr", key, delta)
+func (c *Client) Increment(ctx context.Context, key string, delta uint64) (newValue uint64, err error) {
+	ctx, span := trace.StartSpan(ctx, "memcache.(*Client).Increment")
+	defer span.End()
+
+	return c.incrDecr(ctx, "incr", key, delta)
 }
 
 // Decrement atomically decrements key by delta. The return value is
@@ -656,28 +739,50 @@ func (c *Client) Increment(key string, delta uint64) (newValue uint64, err error
 // memcached must be an decimal number, or an error will be returned.
 // On underflow, the new value is capped at zero and does not wrap
 // around.
-func (c *Client) Decrement(key string, delta uint64) (newValue uint64, err error) {
-	return c.incrDecr("decr", key, delta)
+func (c *Client) Decrement(ctx context.Context, key string, delta uint64) (newValue uint64, err error) {
+	ctx, span := trace.StartSpan(ctx, "memcache.(*Client).Decrement")
+	defer span.End()
+
+	return c.incrDecr(ctx, "decr", key, delta)
 }
 
-func (c *Client) incrDecr(verb, key string, delta uint64) (uint64, error) {
+func (c *Client) incrDecr(ctx context.Context, verb, key string, delta uint64) (uint64, error) {
+	ctx, span := trace.StartSpan(ctx, "memcache.(*Client).incrDecr")
+	defer span.End()
+
 	var val uint64
-	err := c.withKeyRw(key, func(rw *bufio.ReadWriter) error {
+	err := c.withKeyRw(ctx, key, func(rw *bufio.ReadWriter) error {
+		ctx, span := trace.StartSpan(ctx, "memcache.(*Client).withKey")
+		defer span.End()
+
+		span.Annotate([]trace.Attribute{
+			trace.StringAttribute("verb", verb),
+			// Stringifying uint64 instead of making it int64 to avoid any precision losses.
+			trace.StringAttribute("delta", fmt.Sprintf("%d", delta)),
+		}, "writeReadLine being invoked")
 		line, err := writeReadLine(rw, "%s %s %d\r\n", verb, key, delta)
 		if err != nil {
+			span.SetStatus(trace.Status{Code: int32(codes.Unknown), Message: err.Error()})
 			return err
 		}
 		switch {
 		case bytes.Equal(line, resultNotFound):
+			span.SetStatus(trace.Status{Code: int32(codes.NotFound), Message: ErrCacheMiss.Error()})
+			stats.Record(ctx, mCacheMisses.M(1))
 			return ErrCacheMiss
 		case bytes.HasPrefix(line, resultClientErrorPrefix):
-			errMsg := line[len(resultClientErrorPrefix) : len(line)-2]
-			return errors.New("memcache: client error: " + string(errMsg))
+			errMsg := string(line[len(resultClientErrorPrefix) : len(line)-2])
+			span.SetStatus(trace.Status{Code: int32(codes.Unknown), Message: errMsg})
+			stats.Record(ctx, mClientErrors.M(1))
+			return errors.New("memcache: client error: " + errMsg)
 		}
 		val, err = strconv.ParseUint(string(line[:len(line)-2]), 10, 64)
 		if err != nil {
+			stats.Record(ctx, mParseErrors.M(1))
+			span.SetStatus(trace.Status{Code: int32(codes.Unknown), Message: err.Error()})
 			return err
 		}
+		stats.Record(ctx, mCacheHits.M(1))
 		return nil
 	})
 	return val, err

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -19,6 +19,7 @@ package memcache
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -71,9 +72,9 @@ func TestUnixSocket(t *testing.T) {
 	testWithClient(t, New(sock))
 }
 
-func mustSetF(t *testing.T, c *Client) func(*Item) {
+func mustSetF(t *testing.T, ctx context.Context, c *Client) func(*Item) {
 	return func(it *Item) {
-		if err := c.Set(it); err != nil {
+		if err := c.Set(ctx, it); err != nil {
 			t.Fatalf("failed to Set %#v: %v", *it, err)
 		}
 	}
@@ -85,17 +86,18 @@ func testWithClient(t *testing.T, c *Client) {
 			t.Fatalf(format, args...)
 		}
 	}
-	mustSet := mustSetF(t, c)
+	ctx := context.Background()
+	mustSet := mustSetF(t, ctx, c)
 
 	// Set
 	foo := &Item{Key: "foo", Value: []byte("fooval"), Flags: 123}
-	err := c.Set(foo)
+	err := c.Set(ctx, foo)
 	checkErr(err, "first set(foo): %v", err)
-	err = c.Set(foo)
+	err = c.Set(ctx, foo)
 	checkErr(err, "second set(foo): %v", err)
 
 	// Get
-	it, err := c.Get("foo")
+	it, err := c.Get(ctx, "foo")
 	checkErr(err, "get(foo): %v", err)
 	if it.Key != "foo" {
 		t.Errorf("get(foo) Key = %q, want foo", it.Key)
@@ -110,9 +112,9 @@ func testWithClient(t *testing.T, c *Client) {
 	// Get and set a unicode key
 	quxKey := "Hello_世界"
 	qux := &Item{Key: quxKey, Value: []byte("hello world")}
-	err = c.Set(qux)
+	err = c.Set(ctx, qux)
 	checkErr(err, "first set(Hello_世界): %v", err)
-	it, err = c.Get(quxKey)
+	it, err = c.Get(ctx, quxKey)
 	checkErr(err, "get(Hello_世界): %v", err)
 	if it.Key != quxKey {
 		t.Errorf("get(Hello_世界) Key = %q, want Hello_世界", it.Key)
@@ -123,34 +125,34 @@ func testWithClient(t *testing.T, c *Client) {
 
 	// Set malformed keys
 	malFormed := &Item{Key: "foo bar", Value: []byte("foobarval")}
-	err = c.Set(malFormed)
+	err = c.Set(ctx, malFormed)
 	if err != ErrMalformedKey {
 		t.Errorf("set(foo bar) should return ErrMalformedKey instead of %v", err)
 	}
 	malFormed = &Item{Key: "foo" + string(0x7f), Value: []byte("foobarval")}
-	err = c.Set(malFormed)
+	err = c.Set(ctx, malFormed)
 	if err != ErrMalformedKey {
 		t.Errorf("set(foo<0x7f>) should return ErrMalformedKey instead of %v", err)
 	}
 
 	// Add
 	bar := &Item{Key: "bar", Value: []byte("barval")}
-	err = c.Add(bar)
+	err = c.Add(ctx, bar)
 	checkErr(err, "first add(foo): %v", err)
-	if err := c.Add(bar); err != ErrNotStored {
+	if err := c.Add(ctx, bar); err != ErrNotStored {
 		t.Fatalf("second add(foo) want ErrNotStored, got %v", err)
 	}
 
 	// Replace
 	baz := &Item{Key: "baz", Value: []byte("bazvalue")}
-	if err := c.Replace(baz); err != ErrNotStored {
+	if err := c.Replace(ctx, baz); err != ErrNotStored {
 		t.Fatalf("expected replace(baz) to return ErrNotStored, got %v", err)
 	}
-	err = c.Replace(bar)
+	err = c.Replace(ctx, bar)
 	checkErr(err, "replaced(foo): %v", err)
 
 	// GetMulti
-	m, err := c.GetMulti([]string{"foo", "bar"})
+	m, err := c.GetMulti(ctx, []string{"foo", "bar"})
 	checkErr(err, "GetMulti: %v", err)
 	if g, e := len(m), 2; g != e {
 		t.Errorf("GetMulti: got len(map) = %d, want = %d", g, e)
@@ -169,42 +171,42 @@ func testWithClient(t *testing.T, c *Client) {
 	}
 
 	// Delete
-	err = c.Delete("foo")
+	err = c.Delete(ctx, "foo")
 	checkErr(err, "Delete: %v", err)
-	it, err = c.Get("foo")
+	it, err = c.Get(ctx, "foo")
 	if err != ErrCacheMiss {
 		t.Errorf("post-Delete want ErrCacheMiss, got %v", err)
 	}
 
 	// Incr/Decr
 	mustSet(&Item{Key: "num", Value: []byte("42")})
-	n, err := c.Increment("num", 8)
+	n, err := c.Increment(ctx, "num", 8)
 	checkErr(err, "Increment num + 8: %v", err)
 	if n != 50 {
 		t.Fatalf("Increment num + 8: want=50, got=%d", n)
 	}
-	n, err = c.Decrement("num", 49)
+	n, err = c.Decrement(ctx, "num", 49)
 	checkErr(err, "Decrement: %v", err)
 	if n != 1 {
 		t.Fatalf("Decrement 49: want=1, got=%d", n)
 	}
-	err = c.Delete("num")
+	err = c.Delete(ctx, "num")
 	checkErr(err, "delete num: %v", err)
-	n, err = c.Increment("num", 1)
+	n, err = c.Increment(ctx, "num", 1)
 	if err != ErrCacheMiss {
 		t.Fatalf("increment post-delete: want ErrCacheMiss, got %v", err)
 	}
 	mustSet(&Item{Key: "num", Value: []byte("not-numeric")})
-	n, err = c.Increment("num", 1)
+	n, err = c.Increment(ctx, "num", 1)
 	if err == nil || !strings.Contains(err.Error(), "client error") {
 		t.Fatalf("increment non-number: want client error, got %v", err)
 	}
 	testTouchWithClient(t, c)
 
 	// Test Delete All
-	err = c.DeleteAll()
+	err = c.DeleteAll(ctx)
 	checkErr(err, "DeleteAll: %v", err)
-	it, err = c.Get("bar")
+	it, err = c.Get(ctx, "bar")
 	if err != ErrCacheMiss {
 		t.Errorf("post-DeleteAll want ErrCacheMiss, got %v", err)
 	}
@@ -217,7 +219,8 @@ func testTouchWithClient(t *testing.T, c *Client) {
 		return
 	}
 
-	mustSet := mustSetF(t, c)
+	ctx := context.Background()
+	mustSet := mustSetF(t, ctx, c)
 
 	const secondsToExpiry = int32(2)
 
@@ -233,13 +236,13 @@ func testTouchWithClient(t *testing.T, c *Client) {
 
 	for s := 0; s < 3; s++ {
 		time.Sleep(time.Duration(1 * time.Second))
-		err := c.Touch(foo.Key, secondsToExpiry)
+		err := c.Touch(ctx, foo.Key, secondsToExpiry)
 		if nil != err {
 			t.Errorf("error touching foo: %v", err.Error())
 		}
 	}
 
-	_, err := c.Get("foo")
+	_, err := c.Get(ctx, "foo")
 	if err != nil {
 		if err == ErrCacheMiss {
 			t.Fatalf("touching failed to keep item foo alive")
@@ -248,7 +251,7 @@ func testTouchWithClient(t *testing.T, c *Client) {
 		}
 	}
 
-	_, err = c.Get("bar")
+	_, err = c.Get(ctx, "bar")
 	if nil == err {
 		t.Fatalf("item bar did not expire within %v seconds", time.Now().Sub(setTime).Seconds())
 	} else {
@@ -259,6 +262,7 @@ func testTouchWithClient(t *testing.T, c *Client) {
 }
 
 func BenchmarkOnItem(b *testing.B) {
+	b.ReportAllocs()
 	fakeServer, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		b.Fatal("Could not open fake server: ", err)
@@ -274,16 +278,17 @@ func BenchmarkOnItem(b *testing.B) {
 		}
 	}()
 
+	ctx := context.Background()
 	addr := fakeServer.Addr()
 	c := New(addr.String())
-	if _, err := c.getConn(addr); err != nil {
+	if _, err := c.getConn(ctx, addr); err != nil {
 		b.Fatal("failed to initialize connection to fake server")
 	}
 
 	item := Item{Key: "foo"}
-	dummyFn := func(_ *Client, _ *bufio.ReadWriter, _ *Item) error { return nil }
+	dummyFn := func(_ *Client, _ context.Context, _ *bufio.ReadWriter, _ *Item) error { return nil }
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		c.onItem(&item, dummyFn)
+		c.onItem(ctx, &item, dummyFn)
 	}
 }

--- a/memcache/stats.go
+++ b/memcache/stats.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2018 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package memcache
+
+import (
+	"log"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+const unitDimensionless = "1"
+
+var (
+	// Stats
+	mCacheMisses     = stats.Int64("cache_misses", "Number of cache misses", unitDimensionless)
+	mCacheHits       = stats.Int64("cache_hits", "Number of cache hits", unitDimensionless)
+	mClientErrors    = stats.Int64("client_errors", "Number of general client errors", unitDimensionless)
+	mParseErrors     = stats.Int64("parse_errors", "Number of errors encountered while parsing", unitDimensionless)
+	mIllegalKeys     = stats.Int64("illegal_key", "Number of illegal keys", unitDimensionless)
+	mCASConflicts    = stats.Int64("cas_conflicts", "Number of CAS conflicts", unitDimensionless)
+	mUnstoredResults = stats.Int64("unstored_results", "Number of unstored results", unitDimensionless)
+	mDialErrors      = stats.Int64("dial_errors", "Number of dial errors", unitDimensionless)
+
+	// Views
+	AllViews = []*view.View{
+		{
+			Name:        "gomemcache/cache_hits",
+			Description: "Number of cache hits",
+			Measure:     mCacheHits,
+			Aggregation: view.Count(),
+			TagKeys:     []tag.Key{mustKey("cache_hits")},
+		},
+		{
+			Name:        "gomemcache/cache_misses",
+			Description: "Number of cache misses",
+			Measure:     mCacheMisses,
+			Aggregation: view.Count(),
+			TagKeys:     []tag.Key{mustKey("cache_misses")},
+		},
+		{
+			Name:        "gomemcache/client_errors",
+			Description: "Number of general client errors",
+			Measure:     mClientErrors,
+			Aggregation: view.Count(),
+			TagKeys:     []tag.Key{mustKey("client_errors"), mustKey("miscellaneous_errors")},
+		},
+		{
+			Name:        "gomemcache/parse_errors",
+			Description: "Number of errors encountered while parsing",
+			Measure:     mParseErrors,
+			Aggregation: view.Count(),
+			TagKeys:     []tag.Key{mustKey("parse_errors"), mustKey("miscellaneous_errors")},
+		},
+		{
+			Name:        "gomemcache/illegal_keys",
+			Description: "Number of illegal keys encountered",
+			Measure:     mIllegalKeys,
+			Aggregation: view.Count(),
+			TagKeys:     []tag.Key{mustKey("illegal_keys"), mustKey("miscellaneous_errors")},
+		},
+		{
+			Name:        "gomemcache/cas_conflicts",
+			Description: "Number of CAS conflicts encountered",
+			Measure:     mCASConflicts,
+			Aggregation: view.Count(),
+			TagKeys:     []tag.Key{mustKey("cas_conflicts")},
+		},
+		{
+			Name:        "gomemcache/unstored_results",
+			Description: "Number of unstored results",
+			Measure:     mUnstoredResults,
+			Aggregation: view.Count(),
+			TagKeys:     []tag.Key{mustKey("unstored_results")},
+		},
+		{
+			Name:        "gomemcache/dial_errors",
+			Description: "Number of dial errors",
+			Measure:     mDialErrors,
+			Aggregation: view.Count(),
+			TagKeys:     []tag.Key{mustKey("dial_errors")},
+		},
+	}
+)
+
+func mustKey(strKey string) tag.Key {
+	key, err := tag.NewKey(strKey)
+	if err != nil {
+		log.Fatalf("Failed to create key %q error: %v", strKey, err)
+	}
+	return key
+}


### PR DESCRIPTION
Given caching server
```go
// Copyright 2018, OpenCensus Authors
//
// Licensed under the Apache License, Version 2.0 (the "License");
// you may not use this file except in compliance with the License.
// You may obtain a copy of the License at
//
//     http://www.apache.org/licenses/LICENSE-2.0
//
// Unless required by applicable law or agreed to in writing, software
// distributed under the License is distributed on an "AS IS" BASIS,
// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
// See the License for the specific language governing permissions and
// limitations under the License.

package main

import (
	"context"
	"encoding/json"
	"errors"
	"io/ioutil"
	"log"
	"net/http"
	"time"

	"github.com/orijtech/gomemcache/memcache"
	"google.golang.org/grpc/codes"

	xray "github.com/census-instrumentation/opencensus-go-exporter-aws"
	"go.opencensus.io/exporter/prometheus"
	"go.opencensus.io/exporter/stackdriver"
	"go.opencensus.io/plugin/ochttp"
	"go.opencensus.io/stats/view"
	"go.opencensus.io/trace"

	"github.com/orijtech/otils"
)

var (
	mc         = memcache.New("localhost:11211")
	httpClient = &http.Client{Transport: new(ochttp.Transport)}
)

func main() {
	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
	xe, err := xray.NewExporter(xray.WithVersion("latest"))
	if err != nil {
		log.Fatalf("X-Ray newExporter error: %v", err)
	}

	se, err := stackdriver.NewExporter(stackdriver.Options{
		ProjectID:    otils.EnvOrAlternates("OPENCENSUS_GCP_PROJECTID", "census-demos"),
		MetricPrefix: "memcached",
	})
	if err != nil {
		log.Fatalf("Stackdriver newExporter error: %v", err)
	}
	defer se.Flush()

	pe, err := prometheus.NewExporter(prometheus.Options{Namespace: "memcache_demo"})
	if err != nil {
		log.Fatalf("Prometheus newExporter error: %v", err)
	}

	// Now register the exporters
	trace.RegisterExporter(xe)
	trace.RegisterExporter(se)
	view.RegisterExporter(se)
	view.RegisterExporter(pe)

	// Register all the views
	if err := view.Register(memcache.AllViews...); err != nil {
		log.Fatalf("Failed to register memcache.DefaultStats: %v", err)
	}
	view.SetReportingPeriod(5 * time.Millisecond)

	addr := ":8778"
	mux := http.NewServeMux()
	mux.HandleFunc("/fetch", fetchIt)
	log.Printf("Serving at: %s", addr)
	h := &ochttp.Handler{Handler: mux}
	if err := http.ListenAndServe(addr, h); err != nil {
		log.Fatalf("Serve error: %v", err)
	}
}

type request struct {
	URL string `json:"url"`
}

func fetchIt(w http.ResponseWriter, r *http.Request) {
	ctx, span := trace.StartSpan(r.Context(), "fetchIt")
	defer span.End()

	defer r.Body.Close()
	span.Annotate(nil, "Decoding JSON from request body")
	dec := json.NewDecoder(r.Body)

	rq := new(request)
	if err := dec.Decode(rq); err != nil {
		http.Error(w, err.Error(), http.StatusBadRequest)
		return
	}
	span.Annotate(nil, "Finished decoding JSON from request body")

	blob, err := fetch(ctx, mc, httpClient, rq.URL)
	if err != nil {
		http.Error(w, err.Error(), http.StatusInternalServerError)
		return
	}

	_, _ = w.Write(blob)
}

func fetch(ctx context.Context, mc *memcache.Client, httpClient *http.Client, url string) ([]byte, error) {
	ctx, span := trace.StartSpan(ctx, "fetch")
	defer span.End()

	memoized, err := mc.Get(ctx, url)
	if err == nil && memoized != nil && len(memoized.Value) > 0 {
		span.Annotate(nil, "Cache hit!")
		return memoized.Value, nil
	}

	span.Annotate(nil, "Cache miss")
	span.SetStatus(trace.Status{Code: int32(codes.NotFound), Message: "Cache miss"})

	req, err := http.NewRequest("GET", url, nil)
	if err != nil {
		span.SetStatus(trace.Status{Code: int32(codes.Unknown), Message: err.Error()})
		return nil, err
	}
	req = req.WithContext(ctx)
	res, err := httpClient.Do(req)
	if err != nil {
		span.SetStatus(trace.Status{Code: int32(codes.Internal), Message: err.Error()})
		return nil, err
	}
	if !otils.StatusOK(res.StatusCode) {
		span.SetStatus(trace.Status{Code: int32(codes.Unknown), Message: res.Status})
		return nil, errors.New(res.Status)
	}
	blob, err := ioutil.ReadAll(res.Body)
	if err != nil {
		span.SetStatus(trace.Status{Code: int32(codes.Unknown), Message: err.Error()})
		return nil, err
	}
	_ = res.Body.Close()
	_ = mc.Set(ctx, &memcache.Item{Key: url, Value: blob})
	return blob, nil
}
```