### PR TITLE
add mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/bradfitz/gomemcache
+
+go 1.12


### PR DESCRIPTION
- [go modules](https://github.com/golang/go/wiki/Modules) will be enabled in 1.13.
- after merge it would be nice if you would tag this repo: e.g. `v1.0.0`
  - this will allow consumers something more consistent and readable than `v0.0.0-20181229203832-0af3f3b09a0a`.