### PR TITLE
feat: support passing context

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,25 @@ After this command *gomemcache* is ready to use. Its source will be in:
 
 ## Example
 
-    import (
-            "github.com/bradfitz/gomemcache/memcache"
-    )
+```go
+import (
+    "github.com/bradfitz/gomemcache/memcache"
+)
 
-    func main() {
-         mc := memcache.New("10.0.0.1:11211", "10.0.0.2:11211", "10.0.0.3:11212")
-         mc.Set(&memcache.Item{Key: "foo", Value: []byte("my value")})
+func main() {
+    mc := memcache.New("10.0.0.1:11211", "10.0.0.2:11211", "10.0.0.3:11212")
+    mc.Set(&memcache.Item{Key: "foo", Value: []byte("my value")})
 
-         it, err := mc.Get("foo")
-         ...
-    }
+    it, err := mc.Get("foo")
+
+    // With context
+    ctx, cancel := context.WithTimeout(2 * time.Second)
+    doLongTimeJob(ctx)
+    ...
+    it, err = mc.GetWithContext(ctx, "bar")
+    ...
+}
+```
 
 ## Full docs, see:
 

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -19,6 +19,7 @@ package memcache
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -121,13 +122,23 @@ func testWithClient(t *testing.T, c *Client) {
 		t.Errorf("get(Hello_世界) Value = %q, want hello world", string(it.Value))
 	}
 
+	// Get with expired context
+	key := "foo"
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
+	defer cancel()
+	time.Sleep(1010 * time.Millisecond)
+	it, err = c.GetWithContext(ctx, key)
+	if err != context.DeadlineExceeded {
+		t.Errorf("getWithContext(foo) should return context.DeadlineExceeded instead of %v", err)
+	}
+
 	// Set malformed keys
 	malFormed := &Item{Key: "foo bar", Value: []byte("foobarval")}
 	err = c.Set(malFormed)
 	if err != ErrMalformedKey {
 		t.Errorf("set(foo bar) should return ErrMalformedKey instead of %v", err)
 	}
-	malFormed = &Item{Key: "foo" + string(0x7f), Value: []byte("foobarval")}
+	malFormed = &Item{Key: "foo" + string(rune(0x7f)), Value: []byte("foobarval")}
 	err = c.Set(malFormed)
 	if err != ErrMalformedKey {
 		t.Errorf("set(foo<0x7f>) should return ErrMalformedKey instead of %v", err)
@@ -279,7 +290,7 @@ func BenchmarkOnItem(b *testing.B) {
 
 	addr := fakeServer.Addr()
 	c := New(addr.String())
-	if _, err := c.getConn(addr); err != nil {
+	if _, err := c.getConn(context.TODO(), addr); err != nil {
 		b.Fatal("failed to initialize connection to fake server")
 	}
 
@@ -287,6 +298,6 @@ func BenchmarkOnItem(b *testing.B) {
 	dummyFn := func(_ *Client, _ *bufio.ReadWriter, _ *Item) error { return nil }
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		c.onItem(&item, dummyFn)
+		c.onItem(context.TODO(), &item, dummyFn)
 	}
 }


### PR DESCRIPTION
Sometimes, we may execute a job that takes times longer than the timeout of the incoming requests. In this case, the whole request should be canceled along with all subtasks including the cache operations. But current implementation of `gomemcache` does not support passing context, so we can't cancel the cache operations even if the current context is expired.

So I added the context support for all operations with this PR. I would appreciate it if you think about this feature in a good way.

It keeps the backward compatibility, thus does not affect existing code using `gomemcache`