### PR TITLE
fix problems with the dns resolving cache

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -266,6 +266,17 @@ func (c *Client) dial(addr net.Addr) (net.Conn, error) {
 	}
 
 	if ne, ok := err.(net.Error); ok && ne.Timeout() {
+		addr, ok := addr.(*staticAddr)
+		if ok {
+			err = c.selector.Reresolve(addr)
+			if err == nil {
+				nc, err := net.DialTimeout(addr.Network(), addr.String(), c.netTimeout())
+				if err == nil {
+					return nc, nil
+				}
+			}
+		}
+
 		return nil, &ConnectTimeoutError{addr}
 	}
 


### PR DESCRIPTION
There are problems with connecting to the memcash server by DNS name when changing the IP address of the server.

Due to the fact that the IP address is cached and there is no mechanism for resolving a new address (updating the cache), we get constant errors connecting to the server.

I have added some solution.