### PR TITLE
Faster scanning of memcache responses

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
 
 	"strconv"
@@ -544,6 +545,9 @@ func scanGetResponseLine(line []byte, it *Item) (size int, err error) {
 	val, rest, found = cut(rest, ' ')
 	size64, err := strconv.ParseUint(val, 10, 32)
 	if err != nil {
+		return errf(line)
+	}
+	if size64 > math.MaxInt { // Can happen if int is 32-bit
 		return errf(line)
 	}
 	if !found { // final CAS ID is optional.

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -519,17 +519,49 @@ func parseGetResponse(r *bufio.Reader, cb func(*Item)) error {
 // scanGetResponseLine populates it and returns the declared size of the item.
 // It does not read the bytes of the item.
 func scanGetResponseLine(line []byte, it *Item) (size int, err error) {
-	pattern := "VALUE %s %d %d %d\r\n"
-	dest := []interface{}{&it.Key, &it.Flags, &size, &it.casid}
-	if bytes.Count(line, space) == 3 {
-		pattern = "VALUE %s %d %d\r\n"
-		dest = dest[:3]
-	}
-	n, err := fmt.Sscanf(string(line), pattern, dest...)
-	if err != nil || n != len(dest) {
+	errf := func(line []byte) (int, error) {
 		return -1, fmt.Errorf("memcache: unexpected line in get response: %q", line)
 	}
-	return size, nil
+	if !bytes.HasPrefix(line, []byte("VALUE ")) || !bytes.HasSuffix(line, []byte("\r\n")) {
+		return errf(line)
+	}
+	s := string(line[6 : len(line)-2])
+	var rest string
+	var found bool
+	it.Key, rest, found = cut(s, ' ')
+	if !found {
+		return errf(line)
+	}
+	val, rest, found := cut(rest, ' ')
+	if !found {
+		return errf(line)
+	}
+	flags64, err := strconv.ParseUint(val, 10, 32)
+	if err != nil {
+		return errf(line)
+	}
+	it.Flags = uint32(flags64)
+	val, rest, found = cut(rest, ' ')
+	size64, err := strconv.ParseUint(val, 10, 32)
+	if err != nil {
+		return errf(line)
+	}
+	if !found { // final CAS ID is optional.
+		return int(size64), nil
+	}
+	it.casid, err = strconv.ParseUint(rest, 10, 64)
+	if err != nil {
+		return errf(line)
+	}
+	return int(size64), nil
+}
+
+// Similar to strings.Cut in Go 1.18, but sep can only be 1 byte.
+func cut(s string, sep byte) (before, after string, found bool) {
+	if i := strings.IndexByte(s, sep); i >= 0 {
+		return s[:i], s[i+1:], true
+	}
+	return s, "", false
 }
 
 // Set writes the given item, unconditionally.

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -290,3 +290,14 @@ func BenchmarkOnItem(b *testing.B) {
 		c.onItem(&item, dummyFn)
 	}
 }
+
+func BenchmarkScanGetResponseLine(b *testing.B) {
+	line := []byte("VALUE foobar1234 0 4096 1234\r\n")
+	var it Item
+	for i := 0; i < b.N; i++ {
+		_, err := scanGetResponseLine(line, &it)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -493,8 +493,8 @@ func TestScanGetResponseLine(t *testing.T) {
 			if got.Flags != tt.wantFlags {
 				t.Errorf("flags = %v, want %v", got.Flags, tt.wantFlags)
 			}
-			if got.casid != tt.wantCasid {
-				t.Errorf("flags = %v, want %v", got.casid, tt.wantCasid)
+			if got.CasID != tt.wantCasid {
+				t.Errorf("flags = %v, want %v", got.CasID, tt.wantCasid)
 			}
 			if gotSize != tt.wantSize {
 				t.Errorf("size = %v, want %v", gotSize, tt.wantSize)


### PR DESCRIPTION
Motivation for this change is at https://github.com/grafana/mimir/issues/285#issuecomment-1029143100, where a large program spends 12% of its CPU in this one function.

Re-coded `scanGetResponseLine()` using `IndexByte()` instead of `SScanf()`.
Also added a benchmark.

```
name                   old time/op    new time/op    delta
ScanGetResponseLine-4    4.06µs ± 1%    0.13µs ± 4%  -96.89%  (p=0.008 n=5+5)

name                   old alloc/op   new alloc/op   delta
ScanGetResponseLine-4      128B ± 0%       24B ± 0%  -81.25%  (p=0.008 n=5+5)

name                   old allocs/op  new allocs/op  delta
ScanGetResponseLine-4      7.00 ± 0%      1.00 ± 0%  -85.71%  (p=0.008 n=5+5)
```

This PR is broadly similar to #74, but about twice as fast on my benchmark.
The benchmark in #74 spends <2% of its time in `scanGetResponseLine()` so doesn't show the effect so well.

The partial copy of `strings.Cut()` in this PR allows the code to still build with pre-1.18 Go.
