### PR TITLE
feat: method close connections

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -711,3 +711,16 @@ func (c *Client) incrDecr(verb, key string, delta uint64) (uint64, error) {
 	})
 	return val, err
 }
+
+// Close is a method to close all connection
+func (c *Client) Close() (err error) {
+	for _, freeConns := range c.freeconn {
+		for _, freeconn := range freeConns {
+			err = freeconn.nc.Close()
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -714,6 +714,8 @@ func (c *Client) incrDecr(verb, key string, delta uint64) (uint64, error) {
 
 // Close is a method to close all connection
 func (c *Client) Close() (err error) {
+	c.lk.Lock()
+	defer c.lk.Unlock()
 	for _, freeConns := range c.freeconn {
 		for _, freeconn := range freeConns {
 			err = freeconn.nc.Close()


### PR DESCRIPTION
It was implemented a new method to close all connections.

Code to test
```go
package main

import (
	"fmt"

	"github.com/bradfitz/gomemcache/memcache"
)

func main() {
	memcached := memcache.New("127.0.0.1:11211")
	if err := memcached.Ping(); err != nil {
		fmt.Println("ERRR TO PING", err.Error())
	}

	err := memcached.Set(&memcache.Item{Key: "renan", Value: []byte("bastos")})
	if err != nil {
		fmt.Println("ERROR TO SET DATA", err.Error())
		return
	}

	item, err := memcached.Get("renan")
	if err != nil {
		fmt.Println("ERROR TO GET DATA", err.Error())
		return
	}

	fmt.Println(item)

	err = memcached.Close()
	if err != nil {
		fmt.Println("ERROR TO CLOSE", err.Error())
		return
	}

	item, err = memcached.Get("renan")
	if err != nil {
		fmt.Println("ERROR TO GET DATA", err.Error())
	}

}
```

Evidence:
```
&{renan [98 97 115 116 111 115] 0 0 184880334}
ERROR TO GET DATA write tcp 10.8.0.41:55504->172.16.0.6:11211: use of closed network connection
```