### PR TITLE
feat: add support for append/prepend

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -561,6 +561,26 @@ func (c *Client) replace(rw *bufio.ReadWriter, item *Item) error {
 	return c.populateOne(rw, "replace", item)
 }
 
+// Append appends the given item to the existing item, if a value already
+// exists for its key. ErrNotStored is returned if that condition is not met.
+func (c *Client) Append(item *Item) error {
+	return c.onItem(item, (*Client).append)
+}
+
+func (c *Client) append(rw *bufio.ReadWriter, item *Item) error {
+	return c.populateOne(rw, "append", item)
+}
+
+// Prepend prepends the given item to the existing item, if a value already
+// exists for its key. ErrNotStored is returned if that condition is not met.
+func (c *Client) Prepend(item *Item) error {
+	return c.onItem(item, (*Client).prepend)
+}
+
+func (c *Client) prepend(rw *bufio.ReadWriter, item *Item) error {
+	return c.populateOne(rw, "prepend", item)
+}
+
 // CompareAndSwap writes the given item that was previously returned
 // by Get, if the value was neither modified or evicted between the
 // Get and the CompareAndSwap calls. The item's Key should not change

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -141,6 +141,34 @@ func testWithClient(t *testing.T, c *Client) {
 		t.Fatalf("second add(foo) want ErrNotStored, got %v", err)
 	}
 
+	// Append
+	append := &Item{Key: "append", Value: []byte("appendval")}
+	if err := c.Append(append); err != ErrNotStored {
+		t.Fatalf("first append(append) want ErrNotStored, got %v", err)
+	}
+	c.Set(append)
+	err = c.Append(&Item{Key: "append", Value: []byte("1")})
+	checkErr(err, "second append(append): %v", err)
+	appended, err := c.Get("append")
+	checkErr(err, "third append(append): %v", err)
+	if string(appended.Value) != string(append.Value)+"1" {
+		t.Fatalf("Append: want=append1, got=%s", string(appended.Value))
+	}
+
+	// Prepend
+	prepend := &Item{Key: "prepend", Value: []byte("prependval")}
+	if err := c.Prepend(prepend); err != ErrNotStored {
+		t.Fatalf("first prepend(prepend) want ErrNotStored, got %v", err)
+	}
+	c.Set(prepend)
+	err = c.Prepend(&Item{Key: "prepend", Value: []byte("1")})
+	checkErr(err, "second prepend(prepend): %v", err)
+	prepended, err := c.Get("prepend")
+	checkErr(err, "third prepend(prepend): %v", err)
+	if string(prepended.Value) != "1"+string(prepend.Value) {
+		t.Fatalf("Prepend: want=1prepend, got=%s", string(prepended.Value))
+	}
+
 	// Replace
 	baz := &Item{Key: "baz", Value: []byte("bazvalue")}
 	if err := c.Replace(baz); err != ErrNotStored {


### PR DESCRIPTION
Adds support for `Append` and `Prepend` operations. Includes handling for the case where a key isn't yet set, which causes memcache to throw.