### PR TITLE
feat: add GetMultiFromSingleEndpoint

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -490,6 +490,15 @@ func (c *Client) GetMulti(keys []string) (map[string]*Item, error) {
 	return m, err
 }
 
+func (c *Client) GetMultiFromSingleEndpoint(keys []string, addr net.Addr) (map[string]*Item, error) {
+	m := make(map[string]*Item)
+	addItemToMap := func(it *Item) {
+		m[it.Key] = it
+	}
+	err := c.getFromAddr(addr, keys, addItemToMap)
+	return m, err
+}
+
 // parseGetResponse reads a GET response from r and calls cb for each
 // read and allocated Item
 func parseGetResponse(r *bufio.Reader, cb func(*Item)) error {


### PR DESCRIPTION
When using proxies such as mcrouter, you don't really want to pick multiple servers and split get requests across them. It is more efficient to just send the entire `gets key1 key2 ... keyN` request to one endpoint and have it handle splitting those out to the memcached cluster.

The PickServer interface provided by this library wasn't flexible enough for me to solve this issue, so I added a new function that runs GetMulti but just at a single endpoint. This doesn't need locking or channels since there is just one pipelined request.