### PR TITLE
use FIFO queue for freelist

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -224,8 +224,8 @@ func (c *Client) getFreeConn(addr net.Addr) (cn *conn, ok bool) {
 	if !ok || len(freelist) == 0 {
 		return nil, false
 	}
-	cn = freelist[len(freelist)-1]
-	c.freeconn[addr.String()] = freelist[:len(freelist)-1]
+	cn = freelist[0]
+	c.freeconn[addr.String()] = freelist[1:]
 	return cn, true
 }
 


### PR DESCRIPTION
Using FIFO queue may help with cycling through more evenly. I have noticed the front of the freeconn list can stay underutilized if you have infrequent bursts and a high idle max pool size. Since there is no logic to clean closed idle connections, it might make sense to FIFO through them instead of letting stale connections build up. 