### PR TITLE
Export Compare-And-Swap (CAS) id in Item

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -171,8 +171,11 @@ type Item struct {
 	// Zero means the Item has no expiration time.
 	Expiration int32
 
-	// Compare and swap ID.
-	casid uint64
+	// CasID is the compare and swap ID.
+	//
+	// It's populated by get requests and then the same value is
+	// required for a CompareAndSwap request to succeed.
+	CasID uint64
 }
 
 // conn is a connection to a server.
@@ -535,7 +538,7 @@ func parseGetResponse(r *bufio.Reader, cb func(*Item)) error {
 // It does not read the bytes of the item.
 func scanGetResponseLine(line []byte, it *Item) (size int, err error) {
 	pattern := "VALUE %s %d %d %d\r\n"
-	dest := []interface{}{&it.Key, &it.Flags, &size, &it.casid}
+	dest := []interface{}{&it.Key, &it.Flags, &size, &it.CasID}
 	if bytes.Count(line, space) == 3 {
 		pattern = "VALUE %s %d %d\r\n"
 		dest = dest[:3]
@@ -618,7 +621,7 @@ func (c *Client) populateOne(rw *bufio.ReadWriter, verb string, item *Item) erro
 	var err error
 	if verb == "cas" {
 		_, err = fmt.Fprintf(rw, "%s %s %d %d %d %d\r\n",
-			verb, item.Key, item.Flags, item.Expiration, len(item.Value), item.casid)
+			verb, item.Key, item.Flags, item.Expiration, len(item.Value), item.CasID)
 	} else {
 		_, err = fmt.Fprintf(rw, "%s %s %d %d %d\r\n",
 			verb, item.Key, item.Flags, item.Expiration, len(item.Value))


### PR DESCRIPTION
Even though the CAS id is a transparent token there are use cases where the client of the module could be interested in storing the token from a retrieved Item out-of-process for later use with a CAS operation. This is impossible if the field is unexported.

To put into context:

We are currently building a small service in GO acting as a REST API proxy in front of memcached. We expose the common operations get/set/delete/compare-and-swap and so on, and for this design to hold, we need to include the CAS id in the get response, and have the client of the API supply the CAS id with the compare-and-swap request. As it is today, we can not access the CAS id in the service since it is not exported from the gomemcache library.