### PR TITLE
propogate err to condRelease in withAddrRw

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -363,13 +363,16 @@ func (c *Client) withKeyAddr(key string, fn func(net.Addr) error) (err error) {
 	return fn(addr)
 }
 
-func (c *Client) withAddrRw(addr net.Addr, fn func(*bufio.ReadWriter) error) (err error) {
+func (c *Client) withAddrRw(addr net.Addr, fn func(*bufio.ReadWriter) error) error {
 	cn, err := c.getConn(addr)
 	if err != nil {
 		return err
 	}
 	defer cn.condRelease(&err)
-	return fn(cn.rw)
+	if err = fn(cn.rw); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (c *Client) withKeyRw(key string, fn func(*bufio.ReadWriter) error) error {


### PR DESCRIPTION
Currently, `withAddrRw` always calls `defer cn.condRelease(&err)` which an err that is nil. This means no matter what error happens in `fn`, the connection will get sent back to the pool even if there is a non-resumable error. This isn't ideal because we could be sending bad connections back to the pool.

This PR matches the implementation with `onItem` that seems to handle the error correctly.