### PR TITLE
Update Go testing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,16 +9,23 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.18', '1.21' ]
+        go-version:
+          - '1.18.x'
+          - '1.19.x'
+          - '1.20.x'
+          - '1.21.x'
+          - '1.22.x'
+          - '1.23.x'
+          - '1.24.x'
 
     steps:
       - name: install memcached
         run: |
           sudo apt update
           sudo apt install memcached
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
         with:
           go-version: ${{ matrix.go-version }}
       - name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,12 @@
 name: Test
 on:
   push:
+    branches:
+      - master
   pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -9,16 +14,21 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.18', '1.21' ]
+        go-version:
+          - '1.18.x'
+          - '1.25.x'
+          - '1.26.x'
 
     steps:
       - name: install memcached
         run: |
           sudo apt update
           sudo apt install memcached
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ matrix.go-version }}
       - name: Test


### PR DESCRIPTION
* Update CI to test all latest versions.
* Bump GitHub actions and pin versions for supply chain security.
* Enable dependabot to update GitHub actions.
* Only build on push to master.