### PR TITLE
enhancement: Early return in Each method when no servers are available

### DIFF
--- a/memcache/selector.go
+++ b/memcache/selector.go
@@ -93,6 +93,9 @@ func (ss *ServerList) SetServers(servers ...string) error {
 func (ss *ServerList) Each(f func(net.Addr) error) error {
 	ss.mu.RLock()
 	defer ss.mu.RUnlock()
+	if len(ss.addrs) == 0 {
+		return ErrNoServers
+	}
 	for _, a := range ss.addrs {
 		if err := f(a); nil != err {
 			return err


### PR DESCRIPTION
#### Summary

This PR improves the performance and clarity of the `Each` method in `ServerList` by adding an early return when there are no server addresses (`ss.addrs`) to iterate over.

#### Changes

- Added a `len(ss.addrs) == 0` check at the beginning of `Each()` to return `ErrNoServers` immediately, avoiding unnecessary locking and iteration.
- Improves efficiency, especially in scenarios where `Each()` is frequently called (e.g., `Client.Ping()`).
- Provides clearer behaviour and quicker feedback when the server list is empty.

#### Benefits

- Reduces lock contention.
- Improves `Ping()` response time when no servers are available.
- Fails fast with a meaningful error.