### PR TITLE
replace confusing break with comment

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -460,7 +460,7 @@ func (c *Client) touchFromAddr(addr net.Addr, keys []string, expiration int32) e
 			}
 			switch {
 			case bytes.Equal(line, resultTouched):
-				break
+				// success
 			case bytes.Equal(line, resultNotFound):
 				return ErrCacheMiss
 			default:


### PR DESCRIPTION
`staticcheck ./...` lit a few things up, this being the main one which, i agree with the discussion linked below, was a bit misleading. replaced break with a comment.

Similar to discussion here: https://github.com/dominikh/go-tools/issues/250.
