### PR TITLE
Ping returns ErrNoServers when no servers are configured

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -779,9 +779,21 @@ func (c *Client) getAndTouchFromAddr(addr net.Addr, key string, expiration int32
 }
 
 // Ping checks all instances if they are alive. Returns error if any
-// of them is down.
+// of them is down, or ErrNoServers if the client has no servers
+// configured.
 func (c *Client) Ping() error {
-	return c.selector.Each(c.ping)
+	pinged := false
+	err := c.selector.Each(func(addr net.Addr) error {
+		pinged = true
+		return c.ping(addr)
+	})
+	if err != nil {
+		return err
+	}
+	if !pinged {
+		return ErrNoServers
+	}
+	return nil
 }
 
 // Increment atomically increments key by delta. The return value is

--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -502,3 +502,14 @@ func TestScanGetResponseLine(t *testing.T) {
 		})
 	}
 }
+
+// Regression for #179. A client built with zero servers used to report
+// Ping success because Each iterates over an empty list. Other
+// operations on the same client return ErrNoServers, so Ping should
+// surface the same signal.
+func TestPingNoServers(t *testing.T) {
+	c := New()
+	if err := c.Ping(); err != ErrNoServers {
+		t.Fatalf("Ping() = %v, want ErrNoServers", err)
+	}
+}


### PR DESCRIPTION
Fixes #179.

A client built via \`New()\` without addresses (or one whose \`ServerList\` was emptied later) reported \`Ping()\` success because \`selector.Each\` iterated over an empty list and returned nil. Other operations on the same client return \`ErrNoServers\` in that situation, so callers had no consistent way to tell whether the client could actually reach anything.

Track whether any per-server callback fired and surface \`ErrNoServers\` when none did. Real server errors keep propagating unchanged.

Added \`TestPingNoServers\` covering the zero-server case.